### PR TITLE
create valid syntax when no flag is set

### DIFF
--- a/bin/ledger2beancount-txns
+++ b/bin/ledger2beancount-txns
@@ -124,7 +124,7 @@ sub pp_cur_header() {
     my $buf = "";
 
     $buf .= $cur_txn_header{date} . " ";
-    $buf .= $cur_txn_header{flag} . " " if $cur_txn_header{flag};
+    $buf .= $cur_txn_header{flag} . " ";
     if (exists $cur_txn_header{payee}) {
 	$buf .= (mk_beancount_string $cur_txn_header{payee}) . " ";
     }
@@ -313,7 +313,7 @@ while (my $l = <>) {
     if ($l =~ /^include\s+(?<filename>.*)\.ledger/) {  # include
 	print_line $depth, "include \"$+{filename}.beancount\"";
     } elsif ($l =~ /$txn_header_RE/) {  # txn header
-	push_header $+{date}, $+{flag} ? $+{flag} : "", $+{narration};
+	push_header $+{date}, $+{flag} ? $+{flag} : "txn", $+{narration};
 	push_metadata $depth + 1, $altdate_tag, $+{altdate} if defined $+{altdate} && defined $altdate_tag;
 	push_metadata $depth + 1, $code_tag, mk_beancount_string $+{code} if defined $+{code} && defined $code_tag;
     } elsif ($l =~ /$metadata_RE/ && $in_txn) {  # metadata comment

--- a/tests/code.beancount
+++ b/tests/code.beancount
@@ -18,7 +18,7 @@ include "avg-cost-adjustments.beancount"
   Equity:Opening-Balance            -10.00 EUR
 
 ; Code but no flag
-2018-03-17 "Test"
+2018-03-17 txn "Test"
   code: "AT20"
   Assets:Test                        10.00 EUR
   Equity:Opening-Balance            -10.00 EUR

--- a/tests/flags.beancount
+++ b/tests/flags.beancount
@@ -5,7 +5,7 @@ include "avg-cost-adjustments.beancount"
 ; see: https://bitbucket.org/blais/beancount/issues/147
 
 
-2018-03-17 "Test"
+2018-03-17 txn "Test"
   Assets:Test                        10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
 


### PR DESCRIPTION
ledger and beancount allow optional flags on transactions.  While
these are strictly optional in ledger, transactions have to be
marked as such using "txn" if no flag is set.