### PR TITLE
differentiate between commodities and currencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.6"
 install:
-  - sudo apt-get install libcarp-assert-perl libdate-calc-perl libyaml-libyaml-perl libfile-basedir-perl
+  - sudo apt-get install libcarp-assert-perl libdate-calc-perl libyaml-libyaml-perl libfile-basedir-perl libexperimental-perl
   - pip install beancount==2.0rc1
 script:
   - make test

--- a/bin/ledger2beancount-txns
+++ b/bin/ledger2beancount-txns
@@ -8,6 +8,7 @@
 
 use strict;
 use warnings;
+use experimental 'smartmatch';
 
 use Carp::Assert;
 use Date::Calc qw(Add_Delta_Days);
@@ -359,9 +360,26 @@ while (my $l = <>) {
 	    my $date = "";
 	    $date = ", $+{date}" if (defined $+{date});
 	    if (not defined $+{lot_cost}) {
-		# No ledger lot cost, only lot price.  Convert lot price to a
-		# beancount cost, which is required to ensure cost basis
-		$l = sprintf "$+{posting} %s$+{lot_price}$date%s", "{" x length $+{at}, "}" x length $+{at};
+		# No ledger lot cost, only price.  This one is tricky
+		# because this convention can be used for two different
+		# purposes:
+		# 1) For conversion between currencies where you do not
+		# generally wish to retain the cost.
+		# 2) To acquire/dispose of commodities (e.g. shares)
+		# where you want to retain the cost.
+		#
+		# Most currencies have 3 characters (e.g. EUR, USD, GBP)
+		# whereas commodities often have more (e.g. the ISIN).
+		# Therefore, we assume the cost should not be kept if
+		# both currencies have 3 characters.  Since this won't
+		# work in all cases, we also check for a list of
+		# commodities.
+		if ((length $+{commodity} == 3 && length((split / /, $+{lot_price}, 2)[1]) == 3)
+		    && !($+{commodity} ~~ @{$config->{commodities3char}})) {
+		    $l = sprintf "$+{posting} %s $+{lot_price}", "@" x length $+{at};
+		} else {
+		    $l = sprintf "$+{posting} %s$+{lot_price}$date%s", "{" x length $+{at}, "}" x length $+{at};
+		}
 	    } elsif ($+{lot_cost} eq $+{lot_price}) {
 		# ledger requires you to specify both lot cost and lot price
 		# due to a bug.  If both are the same, don't put in the price.

--- a/ledger2beancount.yml
+++ b/ledger2beancount.yml
@@ -39,3 +39,11 @@ commodity_map:
 altdate_tag: alt-date
 code_tag: code
 
+# A list of commodities that should be treated as commodities
+# rather than currencies even though they consist of 3 characters
+# (which is usually a characteristic of a currency)
+commodities3char:
+  - BTC
+  - ETH
+  - IBM
+

--- a/runtests
+++ b/runtests
@@ -3,14 +3,14 @@
 TEST_DIR=tests
 status=0
 
-run_test () {
+test_conversion () {
 	file=$1
 	test=$(basename "$file")
 	expected=$(echo $file | sed -e 's/.ledger$/.beancount/')
 
 	actual=$(tempfile)
 
-	printf "Test $test... "
+	printf "Converting $test... "
 
 	cat $file | bin/ledger2beancount-txns > $actual
 
@@ -25,9 +25,28 @@ run_test () {
 	rm -f $actual
 }
 
-YEAR=${1:-*}
+test_validity () {
+	file=$1
+	test=$(basename "$file")
+	printf "Validating $test... "
+	beancount=$(tempfile)
+	cat $TEST_DIR/def-accounts| bin/ledger2beancount-accounts > $beancount
+	cat $file >> $beancount
+	if bean-check $beancount; then
+		echo "ok"
+	else
+		echo "FAIL"
+		status=1
+	fi
+	rm -f $beancount
+}
+
 for test in `find $TEST_DIR/ -name "*.ledger" | sort`; do
-	run_test "$test"
+	test_conversion "$test"
+done
+
+for test in `find $TEST_DIR/ -name "*.beancount" | sort`; do
+	test_validity "$test"
 done
 
 exit $status

--- a/tests/def-accounts
+++ b/tests/def-accounts
@@ -1,0 +1,10 @@
+
+account Assets:Test
+    note Just a test account
+
+account Equity:Opening-Balance
+    note Opening balances
+
+account Income:Capital-Gain
+    note Capital gains
+

--- a/tests/lots.beancount
+++ b/tests/lots.beancount
@@ -83,10 +83,26 @@ option "operating_currency" "EUR"
   Income:Capital-Gain       -0.50 GBP
 
 2018-03-17 * "Test"
-  Assets:Test               10.00 EUR {0.90 GBP}
+  Assets:Test               10.00 EUR @ 0.90 GBP
   Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * "Test"
-  Assets:Test               10.00 EUR {{9.00 GBP}}
+  Assets:Test               10.00 EUR @@ 9.00 GBP
   Equity:Opening-Balance    -9.00 GBP
+
+2018-03-17 * "Test"
+  Assets:Test        1 LU0274208692 {48.67 EUR}
+  Equity:Opening-Balance   -48.67 EUR
+
+2018-03-17 * "Test"
+  Assets:Test        1 LU0274208692 {{48.67 EUR}}
+  Equity:Opening-Balance   -48.67 EUR
+
+2018-03-17 * "Test"
+  Assets:Test               1.00 ETH {6500.00 EUR}
+  Equity:Opening-Balance    -6500.00 EUR
+
+2018-03-17 * "Test"
+  Assets:Test               1.00 ETH {{6500.00 EUR}}
+  Equity:Opening-Balance    -6500.00 EUR
 

--- a/tests/lots.ledger
+++ b/tests/lots.ledger
@@ -88,3 +88,19 @@
     Assets:Test               10.00 EUR @@ 9.00 GBP
     Equity:Opening-Balance    -9.00 GBP
 
+2018-03-17 * Test
+    Assets:Test        1 "LU0274208692" @ 48.67 EUR
+    Equity:Opening-Balance   -48.67 EUR
+
+2018-03-17 * Test
+    Assets:Test        1 "LU0274208692" @@ 48.67 EUR
+    Equity:Opening-Balance   -48.67 EUR
+
+2018-03-17 * Test
+    Assets:Test               1.00 ETH @ 6500.00 EUR
+    Equity:Opening-Balance    -6500.00 EUR
+
+2018-03-17 * Test
+    Assets:Test               1.00 ETH @@ 6500.00 EUR
+    Equity:Opening-Balance    -6500.00 EUR
+

--- a/tests/tags.beancount
+++ b/tests/tags.beancount
@@ -3,7 +3,6 @@ option "operating_currency" "EUR"
 
 2018-03-17 * "Test"
   tags: "foo, bar, baz"
-  tags: "test"
   Assets:Test                        10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
 

--- a/tests/tags.ledger
+++ b/tests/tags.ledger
@@ -1,7 +1,6 @@
 
 2018-03-17 * Test
     ; :foo:bar:baz:
-    ; :test:
     Assets:Test                        10.00 EUR
     Equity:Opening-Balance            -10.00 EUR
 


### PR DESCRIPTION
Something like "Assets:Foo   10.00 FOO @@ BAR" should be converted
to beancount in different ways depending on whether it's a currency
(where you generally don't wish to retain the cost) or a commodity,
such as shares (where you want to retain the cost).

Most currencies have 3 characters (e.g. EUR, USD, GBP)
whereas commodities often have more (e.g. the ISIN).
Therefore, we assume the cost should not be kept if
both currencies have 3 characters.