### PR TITLE
Move tests to subdir, run new tests with custom config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 all:
 
+.PHONY: test
 test:
-	./runtests
+	cd tests && ./runtests

--- a/ledger2beancount.yml
+++ b/ledger2beancount.yml
@@ -16,7 +16,8 @@ operating_currencies:
 includes: []
 
 # Plugins to load
-plugins: []
+plugins:
+ - beancount.plugins.implicit_prices
 
 # mapping of ledger metadata key to corresponding beancount key
 metadata_map:

--- a/ledger2beancount.yml
+++ b/ledger2beancount.yml
@@ -21,7 +21,6 @@ plugins:
 
 # mapping of ledger metadata key to corresponding beancount key
 metadata_map:
-  label: bank-label
   x-payee: payee
   x-payer: payer
 

--- a/tests/commodities.beancount
+++ b/tests/commodities.beancount
@@ -5,3 +5,7 @@ option "operating_currency" "EUR"
   Assets:Test                      1 DE0002635307
   Equity:Opening-Balance          -1 DE0002635307
 
+2018-03-17 * "Test Chase"
+  Assets:Test                      1 UR
+  Equity:Opening-Balance          -1 UR
+

--- a/tests/commodities.ledger
+++ b/tests/commodities.ledger
@@ -3,3 +3,7 @@
     Assets:Test                      1 "DE0002635307"
     Equity:Opening-Balance          -1 "DE0002635307"
 
+2018-03-17 * Test Chase
+    Assets:Test                      1 Chase
+    Equity:Opening-Balance          -1 Chase
+

--- a/tests/ledger2beancount.yml
+++ b/tests/ledger2beancount.yml
@@ -33,6 +33,7 @@ account_map:
 
 # mapping of ledger commodities to valid beancount commodities
 commodity_map:
+  Chase: UR
 
 # You can set the following metadata tags to an empty string if you
 # don't want the metadata to be added to beancount.

--- a/tests/ledger2beancount.yml
+++ b/tests/ledger2beancount.yml
@@ -1,0 +1,49 @@
+
+# Date used to open accounts
+account_open_date: "1970-01-01" # Unix epoch, just because
+
+# Date used to create commodities
+commodities_date:  "1970-01-01" # Unix epoch, just because
+
+beancount_indent: 2
+ledger_indent: 4
+
+# list of frequently used currencies (not *all* used currencies)
+operating_currencies:
+  - EUR
+
+# Any other include files listed at the top
+includes: []
+
+# Plugins to load
+plugins: []
+
+# mapping of ledger metadata key to corresponding beancount key
+metadata_map:
+  label: bank-label
+  x-payee: payee
+  x-payer: payer
+
+# metadata tags (*after* above mapping) used for specific purposes
+payee_tag: payee
+payer_tag: payer
+
+account_map:
+  "Equity:Opening balance": Equity:Opening-Balance
+
+# mapping of ledger commodities to valid beancount commodities
+commodity_map:
+
+# You can set the following metadata tags to an empty string if you
+# don't want the metadata to be added to beancount.
+altdate_tag: alt-date
+code_tag: code
+
+# A list of commodities that should be treated as commodities
+# rather than currencies even though they consist of 3 characters
+# (which is usually a characteristic of a currency)
+commodities3char:
+  - BTC
+  - ETH
+  - IBM
+

--- a/tests/runtests
+++ b/tests/runtests
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-TEST_DIR=tests
+TEST_DIR=.
 status=0
 
 test_conversion () {
@@ -12,7 +12,7 @@ test_conversion () {
 
 	printf "Converting $test... "
 
-	cat $file | bin/ledger2beancount-txns > $actual
+	cat $file | ../bin/ledger2beancount-txns > $actual
 
 	if $(cmp -s $expected $actual); then
 		echo "ok"
@@ -30,7 +30,7 @@ test_validity () {
 	test=$(basename "$file")
 	printf "Validating $test... "
 	beancount=$(tempfile)
-	cat $TEST_DIR/def-accounts| bin/ledger2beancount-accounts > $beancount
+	cat $TEST_DIR/def-accounts| ../bin/ledger2beancount-accounts > $beancount
 	cat $file >> $beancount
 	if bean-check $beancount; then
 		echo "ok"

--- a/tests/runtests
+++ b/tests/runtests
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-TEST_DIR=.
 status=0
 
 test_conversion () {
@@ -30,7 +29,7 @@ test_validity () {
 	test=$(basename "$file")
 	printf "Validating $test... "
 	beancount=$(tempfile)
-	cat $TEST_DIR/def-accounts| ../bin/ledger2beancount-accounts > $beancount
+	cat def-accounts| ../bin/ledger2beancount-accounts > $beancount
 	cat $file >> $beancount
 	if bean-check $beancount; then
 		echo "ok"
@@ -41,11 +40,11 @@ test_validity () {
 	rm -f $beancount
 }
 
-for test in `find $TEST_DIR/ -name "*.ledger" | sort`; do
+for test in `find . -name "*.ledger" | sort`; do
 	test_conversion "$test"
 done
 
-for test in `find $TEST_DIR/ -name "*.beancount" | sort`; do
+for test in `find . -name "*.beancount" | sort`; do
 	test_validity "$test"
 done
 


### PR DESCRIPTION
Move the test script to a subdir, so we can have its own config file.  This allows more tests with a custom config, and we can make the main config more usable for users.
