### PR TITLE
add option to render tags as tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,50 @@ the config file `ledger2beancount.yml` and if that is not found for
 file for the variables.
 
 
+FUNCTIONALITY
+-------------
+
+### Tags
+
+Beancount currently has two limitations regarding tags:
+
+1. they have to be on the same line as the narration ([issue
+99](https://bitbucket.org/blais/beancount/issues/99)), which means the
+line can get very long.  It would be good to put tags on a line on its
+own before the first posting but this currently doesn't work.
+
+2. postings can't have tags ([issue
+144](https://bitbucket.org/blais/beancount/issues/144)).
+
+Because of these limitations, ledger2beancount offers two ways to handle
+tags using the `tag_as_metadata` variable:
+
+If `tag_as_metadata` is `true`, tags will be stored as metadata with the
+key `tags`.  This works both for transactions and postings.  This option
+should be seen as a workaround because metadata with the key `tags` is
+not seen the same by beancount as proper tags.
+
+If `tag_as_metadata` is `false`, transaction tags will be put after the
+narration as tags.  Because of the limitation in beancount, posting-level
+tags are currently ignored.  If tags are rendered as tags, you can define
+[regular expressions](https://perldoc.perl.org/perlre.html#Regular-Expressions)
+in `link_tags` to determine that a tag should be rendered as a link
+instead.  For example, if you tag your trips in the format
+`YYYY-MM-DD-foo`, you could use
+
+    link_tags:
+      - ^\d\d\d\d-\d\d-\d\d-
+
+to render them as links.  So the ledger transaction header
+
+    2018-02-02 * Train Brussels airport to city
+        ; :2018-02-02-brussels-fosdem:debian:
+
+would become the following in beancount:
+
+    2018-02-02 * "Train Brussels airport to city" ^2018-02-02-brussels-fosdem #debian
+
+
 AUTHORS
 -------
 

--- a/bin/ledger2beancount-txns
+++ b/bin/ledger2beancount-txns
@@ -108,6 +108,9 @@ sub pp_cur_header() {
 	$buf .= (mk_beancount_string $cur_txn_header{payee}) . " ";
     }
     $buf .= mk_beancount_string $cur_txn_header{narration};
+    if (exists $cur_txn_header{tags}) {
+        $buf .= $cur_txn_header{tags};
+    }
 
     return $buf;
 }
@@ -130,6 +133,18 @@ sub pp_metadata($$) {
     return "$key: $value";
 }
 
+
+# determine whether something should be a link or a tag
+sub tag_or_link(@) {
+    my ($key) = @_;
+
+    foreach my $link_RE (@{$config->{link_tags}}) {
+	return '^' . $key if $key =~ /$link_RE/;
+    }
+    return "#" . $key;
+}
+
+
 # pretty print in-transaction tags, in beancount format
 sub pp_tags(@) {
     my @tags = @_;
@@ -137,7 +152,11 @@ sub pp_tags(@) {
     # XXX workaround for the fact that per-posting tags are currently not
     # allowed.  See:
     # https://groups.google.com/forum/#!topic/beancount/XPtFOnqCVws
-    return "tags: \"" . join(', ', @tags) . "\"";
+    if ($config->{tag_as_metadata}) {
+	return "tags: \"" . join(', ', @tags) . "\"";
+    } else {
+	return join(' ', map tag_or_link($_), @tags);
+    }
 }
 
 # dump the current parsing state to stdout. Used for debugging purposes only
@@ -331,8 +350,11 @@ while (my $l = <>) {
 	     or $l =~ /^;\s+:$tags_RE:\s+(?<comment>.*)$/) {
     	# tags comment
     	if ($in_txn) {
-	    push_line $depth, pp_tags(split(/:/, $+{tags}));
-	    push_comment $depth, $+{comment} if $+{comment} ne "";
+	    if ($config->{tag_as_metadata}) {
+		push_line $depth, pp_tags(split(/:/, $+{tags}));
+	    } else {
+		$cur_txn_header{tags} .= " " . pp_tags(split(/:/, $+{tags})) if $depth == 1;
+	    }
     	} else {
     	    print_line $depth, $l;
     	}

--- a/ledger2beancount.yml
+++ b/ledger2beancount.yml
@@ -39,6 +39,16 @@ commodity_map:
 altdate_tag: aux-date
 code_tag: code
 
+# Render tags as metadata instead of tags:
+# If true, tags are stored as metadata with the key "tags"
+# If false, tags are rendered as #tags after the narration
+tag_as_metadata: false
+
+# A list of regular expressions that will cause a tag to be
+# rendered as a link. (Only works if tag_as_metadata is false)
+link_tag:
+  - ^\d\d\d\d-\d\d-\d\d-
+
 # A list of commodities that should be treated as commodities
 # rather than currencies even though they consist of 3 characters
 # (which is usually a characteristic of a currency)

--- a/tests/ledger2beancount.yml
+++ b/tests/ledger2beancount.yml
@@ -42,6 +42,11 @@ commodity_map:
 altdate_tag: aux-date
 code_tag: code
 
+tag_as_metadata: false
+
+link_tags:
+  - ^\d\d\d\d-\d\d-\d\d-
+
 # A list of commodities that should be treated as commodities
 # rather than currencies even though they consist of 3 characters
 # (which is usually a characteristic of a currency)

--- a/tests/tags.beancount
+++ b/tests/tags.beancount
@@ -1,13 +1,24 @@
 option "operating_currency" "EUR"
 
 
-2018-03-17 * "Test"
-  tags: "foo, bar, baz"
+2018-03-17 * "Tag on transaction" #foo #bar #baz
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-17 * "Tag on transaction, split over two lines" #foo #bar #baz #second
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-17 * "Tag on transaction, one converted to a link" #foo #bar ^2018-02-02-brussels-fosdem #baz
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-17 * "Tag on postings" #foo #bar #baz
   Assets:Test                        10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
 
 ; label will be mapped to bank-label
-2018-03-17 * "Test"
+2018-03-17 * "Map meta data"
   bank-label: "foo"
   Assets:Test                        10.00 EUR
   Equity:Opening-Balance            -10.00 EUR

--- a/tests/tags.ledger
+++ b/tests/tags.ledger
@@ -1,11 +1,29 @@
 
-2018-03-17 * Test
+2018-03-17 * Tag on transaction
     ; :foo:bar:baz:
     Assets:Test                        10.00 EUR
     Equity:Opening-Balance            -10.00 EUR
 
+2018-03-17 * Tag on transaction, split over two lines
+    ; :foo:bar:baz:
+    ; :second:
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-03-17 * Tag on transaction, one converted to a link
+    ; :foo:bar:2018-02-02-brussels-fosdem:baz:
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-03-17 * Tag on postings
+    ; :foo:bar:baz:
+    Assets:Test                        10.00 EUR
+        ; :foo:
+    Equity:Opening-Balance            -10.00 EUR
+        ; :bar:
+
 ; label will be mapped to bank-label
-2018-03-17 * Test
+2018-03-17 * Map meta data
     ; label: foo
     Assets:Test                        10.00 EUR
     Equity:Opening-Balance            -10.00 EUR


### PR DESCRIPTION
Because of limitations in beancount, tags are currently stored as
meta data.  Some people might prefer proper #tags though (even if
with limited functionality).