### PR TITLE
allow payees to be set based on the narration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,70 @@ file for the variables.
 FUNCTIONALITY
 -------------
 
+### Narration
+
+The ledger payee information, which is generally used as free-form text
+to describe the transaction, is stored in beancount's narration field
+and properly quoted.
+
+### Payees
+
+Ledger has limited support for payees.  A `payee` metadata key can be set
+but this also overrides the free-form text to describe the transaction.
+In ledger2beancount, we offer several features to determine the payee.
+
+You can set `payee_split` and define a list of regular expressions which
+allow you to split ledger's payee field into payee and narration.  You
+have to use [Perl regular
+expressions](https://perldoc.perl.org/perlre.html#Regular-Expressions)
+with the named capture groups `payee` and `narration`.  For example,
+given the ledger transaction
+
+    2018-03-18 * Supermarket (Tesco)
+
+and the configuration
+
+    payee_split:
+      - (?<narration>.*?)\s+\((?<payee>Tesco)\)
+
+ledger2beancount will create this beancount transaction:
+
+    2018-03-18 * "Tesco" "Supermarket"
+
+In other words, `payee_split` allows you to split the ledger payee
+into payee and narration in beancount.
+
+`payee_split` is a list of regular expressions and we stop when we
+find a match.
+
+Furthermore, you can use `payee_match` to match based on the ledger
+payee field and assign payees according to the match.  This variable
+is a hash consisting of a regular expressions and the corresponding
+payees.  For example, if your ledger contains a transaction like:
+
+    2018-03-18 * Oyster card top-up
+
+you can use
+
+    payee_split:
+      ^Oyster card top-up: Transport for London
+
+to match the line and assign the payee `Transport for London`:
+
+    2018-03-18 * "Transport for London" "Oyster card top-up"
+
+Unlike `payee_split`, the full payee field from ledger is used as the
+narration in beancount.  Again, we stop after the first match.
+
+Please note that the `payee_match` is done after `payee_split` and we run
+`payee_match` even if `payee_split` matched.  This allows you to remove
+some information from the narration using `payee_split` while overriding
+the found payee using `payee_match`.
+
+Finally, metadata describing a payee or payer will be used to set the
+payee.  The tags used for that information can be specified in
+`payee_tag` and `payer_tag`.
+
 ### Tags
 
 Beancount currently has two limitations regarding tags:

--- a/bin/ledger2beancount-txns
+++ b/bin/ledger2beancount-txns
@@ -329,6 +329,21 @@ while (my $l = <>) {
 	push_header $+{date}, $+{flag} ? $+{flag} : "txn", $+{narration};
 	push_metadata $depth + 1, $config->{altdate_tag}, $+{altdate} if defined $+{altdate} && defined $config->{altdate_tag};
 	push_metadata $depth + 1, $config->{code_tag}, mk_beancount_string $+{code} if defined $+{code} && defined $config->{code_tag};
+	# Determine payee based on the narration field
+	my $narration = $+{narration};
+	foreach my $custom_narration_RE (@{$config->{payee_split}}) {
+	    if ($narration =~ /$custom_narration_RE/) {
+		push_payee $+{payee};
+		$cur_txn_header{narration} = $+{narration};
+		last;
+	    }
+	}
+	foreach my $custom_narration_RE (keys %{$config->{payee_match}}) {
+	    if ($narration =~ /$custom_narration_RE/) {
+		push_payee $config->{payee_match}{$custom_narration_RE};
+		last;
+	    }
+	}
     } elsif ($l =~ /$metadata_RE/ && $in_txn) {  # metadata comment
 	my $key = map_metadata(lc($+{key}));
 	my $value;

--- a/ledger2beancount.yml
+++ b/ledger2beancount.yml
@@ -28,6 +28,19 @@ metadata_map:
 payee_tag: payee
 payer_tag: payer
 
+# payee_split: a list of regular expressions which allows you
+# to split ledger's payee field into payee and narration.
+# Use named capture groups "payee" and "narration".
+payee_split:
+  - (?<narration>.*?)\s+\((?<payee>Tesco)\)
+
+# payee_match: a hash of regular expressions and corresponding
+# payees.  The whole ledger payee becomes the narration and
+# the matched payee from the regular expression becomes the
+# payee.
+payee_match:
+  ^Oyster top-up: TfL
+
 account_map:
   "Equity:Opening balance": Equity:Opening-Balance
 

--- a/tests/ledger2beancount.yml
+++ b/tests/ledger2beancount.yml
@@ -28,6 +28,12 @@ metadata_map:
 payee_tag: payee
 payer_tag: payer
 
+payee_split:
+  - (?<narration>.*?)\s+\((?<payee>Tesco)\)
+
+payee_match:
+  ^Oyster card top-up: TfL
+
 account_map:
   "Equity:Opening balance": Equity:Opening-Balance
 

--- a/tests/payee.beancount
+++ b/tests/payee.beancount
@@ -1,0 +1,19 @@
+option "operating_currency" "EUR"
+
+
+2018-03-18 * "Foo" "Payee Foo"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-18 * "Bar" "Payer Bar"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-18 * "TfL" "Oyster card top-up"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-18 * "Tesco" "Supermarket"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+

--- a/tests/payee.ledger
+++ b/tests/payee.ledger
@@ -1,0 +1,19 @@
+
+2018-03-18 * Payee Foo
+    ; payee: Foo
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-03-18 * Payer Bar
+    ; payer: Bar
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-03-18 * Oyster card top-up
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-03-18 * Supermarket (Tesco)
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+


### PR DESCRIPTION
Ledger only has a payee field which is typically used as a free-form text to describe the transaction.  Introduce two mechanisms to set the payee based on that narration.
