### PR TITLE
rename link_tags to link_match

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ If `tag_as_metadata` is `false`, transaction tags will be put after the
 narration as tags.  Because of the limitation in beancount, posting-level
 tags are currently ignored.  If tags are rendered as tags, you can define
 [regular expressions](https://perldoc.perl.org/perlre.html#Regular-Expressions)
-in `link_tags` to determine that a tag should be rendered as a link
+in `link_match` to determine that a tag should be rendered as a link
 instead.  For example, if you tag your trips in the format
 `YYYY-MM-DD-foo`, you could use
 
-    link_tags:
+    link_match:
       - ^\d\d\d\d-\d\d-\d\d-
 
 to render them as links.  So the ledger transaction header

--- a/bin/ledger2beancount-txns
+++ b/bin/ledger2beancount-txns
@@ -138,7 +138,7 @@ sub pp_metadata($$) {
 sub tag_or_link(@) {
     my ($key) = @_;
 
-    foreach my $link_RE (@{$config->{link_tags}}) {
+    foreach my $link_RE (@{$config->{link_match}}) {
 	return '^' . $key if $key =~ /$link_RE/;
     }
     return "#" . $key;

--- a/ledger2beancount.yml
+++ b/ledger2beancount.yml
@@ -46,7 +46,7 @@ tag_as_metadata: false
 
 # A list of regular expressions that will cause a tag to be
 # rendered as a link. (Only works if tag_as_metadata is false)
-link_tag:
+link_match:
   - ^\d\d\d\d-\d\d-\d\d-
 
 # A list of commodities that should be treated as commodities

--- a/tests/ledger2beancount.yml
+++ b/tests/ledger2beancount.yml
@@ -44,7 +44,7 @@ code_tag: code
 
 tag_as_metadata: false
 
-link_tags:
+link_match:
   - ^\d\d\d\d-\d\d-\d\d-
 
 # A list of commodities that should be treated as commodities


### PR DESCRIPTION
link_match is a better name for what is currently called link_tags.
The *_tags variables are used to define metadata tags.  And while
this is currently not supported, some users might have a specific
metadata key to define links.