### PR TITLE
restore support for comments on same line as tags

### DIFF
--- a/bin/ledger2beancount-txns
+++ b/bin/ledger2beancount-txns
@@ -370,6 +370,7 @@ while (my $l = <>) {
 	    } else {
 		$cur_txn_header{tags} .= " " . pp_tags(split(/:/, $+{tags})) if $depth == 1;
 	    }
+	    push_comment $depth, $+{comment} if $+{comment} ne "";
     	} else {
     	    print_line $depth, $l;
     	}

--- a/tests/comments.beancount
+++ b/tests/comments.beancount
@@ -11,4 +11,17 @@ option "operating_currency" "EUR"
   Assets:Test                        10.00 EUR ; What an "interesting" accout name
   comment: "see beancount issue #143"
   Equity:Opening-Balance            -10.00 EUR ; Opening balance?
+    comment: "posting-level comment"
+
+2018-03-17 * "Tag and comment on same line" #tag
+  comment: "comment"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-17 * "Multi-line comment"
+  comment: "
+    comment1
+    comment2"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
 

--- a/tests/comments.ledger
+++ b/tests/comments.ledger
@@ -7,6 +7,18 @@
 2018-03-17 * Test
     ; Another comment
     Assets:Test                        10.00 EUR ; What an "interesting" accout name
-    ; Comment: see beancount issue #143
+    ; see beancount issue #143
     Equity:Opening-Balance            -10.00 EUR ; Opening balance?
+        ; posting-level comment
+
+2018-03-17 * Tag and comment on same line
+    ; :tag: comment
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-03-17 * Multi-line comment
+    ; comment1
+    ; comment2
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
 


### PR DESCRIPTION
In commit 16e44b4 ("render tags as #tags by default") I accidentally
removed a line which printed comments after tags.

Fixes #21