### PR TITLE
don't parse digits at the end of account name as the amount

### DIFF
--- a/bin/ledger2beancount-txns
+++ b/bin/ledger2beancount-txns
@@ -416,7 +416,7 @@ while (my $l = <>) {
 	$l =~ s/$account/$beancount_account/;
 
 	if ($l =~ /$amount_RE/) {
-	    $l =~ s/$amount_RE/$1 @{[map_commodity($2)]}/;
+	    $l =~ s/(\s+)$amount_RE/$1$2 @{[map_commodity($3)]}/;
 	}
 
 	if ($l =~ /^$posting_RE\s*=\s*(?<assertion>$amount_RE)/) {

--- a/tests/commodities.beancount
+++ b/tests/commodities.beancount
@@ -25,3 +25,7 @@ option "operating_currency" "EUR"
   Expenses:Test                                         140616 GANDI
   Assets:Test                                          -140616 GANDI
 
+2018-03-20 * "Account name ending in digits - digits not part of amount"
+  Assets:Test123                     10.00 EUR
+  Equity:Opening-Balance
+

--- a/tests/commodities.ledger
+++ b/tests/commodities.ledger
@@ -23,3 +23,7 @@
     Expenses:Test                                         140616 Gandi
     Assets:Test                                          -140616 Gandi
 
+2018-03-20 * Account name ending in digits - digits not part of amount
+    Assets:Test123                     10.00 EUR
+    Equity:Opening-Balance
+

--- a/tests/def-accounts
+++ b/tests/def-accounts
@@ -8,6 +8,9 @@ account Assets:Vouchers:Ranch99
 account Assets:Vouchers:Ranch99:Test99
     note assets
 
+account Assets:Test123
+    note assets
+
 account Liabilities:Credit-Card:Test
     note liability
 


### PR DESCRIPTION
Commit c8cc161 ("ensure commodity rewrites don't apply to account
names") didn't consider account names that end with digits.  These
digits should not be interpreted as part of the amount.