### PR TITLE
parse lot costs even when no lot prices are given

### DIFF
--- a/bin/ledger2beancount-txns
+++ b/bin/ledger2beancount-txns
@@ -438,13 +438,13 @@ while (my $l = <>) {
 	    assert $in_txn;
 	    push_line $depth, $+{posting};
 	    push_assertion $+{account}, $+{assertion};
-	} elsif ($l =~ /^$posting_RE(\s+(?<curlyopen>\{\{?)\s*(?<lot_cost>$amount_RE)\s*(?<curlyclose>\}\}?))?\s+(\[(?<date>$date_RE)\])?\s*(?<at>@@?)\s+(?<lot_price>$amount_RE)/) {
+	} elsif ($l =~ /^$posting_RE(\s+(?<curlyopen>\{\{?)\s*(?<lot_cost>$amount_RE)\s*(?<curlyclose>\}\}?))?\s*(\[(?<date>$date_RE)\])?\s*((?<at>@@?)\s+(?<lot_price>$amount_RE))?/) {
 	    # posting with unit price and optional lot price
 	    # XXX refactor/merge with previous regexp case
 	    assert $in_txn;
 	    my $date = "";
 	    $date = ", " . pp_date $+{date} if (defined $+{date});
-	    if (not defined $+{lot_cost}) {
+	    if (defined $+{lot_price} && not defined $+{lot_cost}) {
 		# No ledger lot cost, only price.  This one is tricky
 		# because this convention can be used for two different
 		# purposes:
@@ -465,18 +465,16 @@ while (my $l = <>) {
 		} else {
 		    $l = sprintf "$+{posting} %s$+{lot_price}$date%s", "{" x length $+{at}, "}" x length $+{at};
 		}
-	    } elsif ($+{lot_cost} eq $+{lot_price}) {
+	    } elsif (defined $+{lot_cost}) {
+		$l = "$+{posting} $+{curlyopen}$+{lot_cost}$date$+{curlyclose}";
 		# ledger requires you to specify both lot cost and lot price
 		# due to a bug.  If both are the same, don't put in the price.
-		$l = "$+{posting} $+{curlyopen}$+{lot_price}$date$+{curlyclose}";
-	    } else {
-		# Both ledger lot cost and lot price.
-		$l = "$+{posting} $+{curlyopen}$+{lot_cost}$date$+{curlyclose} $+{at} $+{lot_price}";
+		if (defined $+{lot_price} && ($+{lot_cost} ne $+{lot_price})) {
+		    $l .= " $+{at} $+{lot_price}";
+		}
 	    }
-	    push_line $depth, $l;
-	} else {
-	    push_line $depth, $l;
 	}
+	push_line $depth, $l;
 	handle_metadata $depth+1, \%metadata_posting if exists $metadata_posting{key};
 	push_metadata $depth + 1, $config->{altdate_tag}, pp_date $altdate if defined $altdate && defined $config->{altdate_tag};
     } elsif ($l =~ /^$/) {  # empty line

--- a/tests/lots.beancount
+++ b/tests/lots.beancount
@@ -14,19 +14,19 @@ option "operating_currency" "EUR"
   Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * "Test"
-  Assets:Test               10.00 EUR { 0.90 GBP}
+  Assets:Test               10.00 EUR {0.90 GBP}
   Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * "Test"
-  Assets:Test               10.00 EUR { 0.90 GBP }
+  Assets:Test               10.00 EUR {0.90 GBP}
   Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * "Test"
-  Assets:Test               10.00 EUR {   0.90 GBP }
+  Assets:Test               10.00 EUR {0.90 GBP}
   Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * "Test"
-  Assets:Test               10.00 EUR {{ 9 GBP}}
+  Assets:Test               10.00 EUR {{9 GBP}}
   Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * "Test"
@@ -40,6 +40,10 @@ option "operating_currency" "EUR"
 2018-03-17 * "Test"
   Assets:Test               10.00 EUR {1.23 USD, 2018-03-16}
   Equity:Opening-Balance   -12.30 USD
+
+2018-03-20 * "Lot cost, no lot price"
+  Assets:Test                1.00 EUR {0.90 GBP, 2018-03-18}
+  Equity:Opening-Balance
 
 2018-03-17 * "Test"
   Assets:Test               10.00 EUR {0.90 GBP}
@@ -64,16 +68,20 @@ option "operating_currency" "EUR"
   Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * "Test"
-  Assets:Test               10.00 EUR {{ 9.00 GBP }}
-  Equity:Opening-Balance    -9.00 GBP
-
-2018-03-17 * "Test"
   Assets:Test               10.00 EUR {{9.00 GBP}}
   Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * "Test"
   Assets:Test               10.00 EUR {{9.00 GBP}}
   Equity:Opening-Balance    -9.00 GBP
+
+2018-03-17 * "Test"
+  Assets:Test               10.00 EUR {{9.00 GBP}}
+  Equity:Opening-Balance    -9.00 GBP
+
+2018-03-20 * "Lot cost, no lot price"
+  Assets:Test                1.00 EUR {{0.90 GBP, 2018-03-18}}
+  Equity:Opening-Balance
 
 2018-03-17 * "Test"
   Assets:Test               10.00 EUR {{12.30 USD, 2018-03-16}}

--- a/tests/lots.ledger
+++ b/tests/lots.ledger
@@ -39,6 +39,10 @@
     Assets:Test               10.00 EUR {1.23 USD}  [2018-03-16] @ 1.23 USD
     Equity:Opening-Balance   -12.30 USD
 
+2018-03-20 * Lot cost, no lot price
+    Assets:Test                1.00 EUR {0.90 GBP} [2018-03-18]
+    Equity:Opening-Balance
+
 2018-03-17 * Test
     Assets:Test               10.00 EUR {0.90 GBP}  @  0.90 GBP
     Equity:Opening-Balance    -9.00 GBP
@@ -72,6 +76,10 @@
 2018-03-17 * Test
     Assets:Test               10.00 EUR {{9.00 GBP}}  @@  9.00 GBP
     Equity:Opening-Balance    -9.00 GBP
+
+2018-03-20 * Lot cost, no lot price
+    Assets:Test                1.00 EUR {{0.90 GBP}} [2018-03-18]
+    Equity:Opening-Balance
 
 2018-03-17 * Test
     Assets:Test               10.00 EUR {{12.30 USD}} [2018-03-16] @@ 12.30 USD


### PR DESCRIPTION
Parse lot costs even when no lot prices are given.  This allows
us to tranform the lot costs, which is required for example when
a date is specified for the lot cost.

Fixes #29