### PR TITLE
fix support for price directive in ledger2beancount-txns

### DIFF
--- a/bin/ledger2beancount-txns
+++ b/bin/ledger2beancount-txns
@@ -436,7 +436,7 @@ while (my $l = <>) {
     } elsif ($l =~ /^$comment_RE/) {  # (every other) comment
 	$in_txn ? push_comment $depth, $+{comment} : print_line $depth, $l;
     } elsif ($l =~ /^$price_RE/) {
-	$l = sprintf "%s price %s $+{num} %s", pp_date $+{date}, map_commodity $+{commodity1}, map_commodity $+{commodity2};
+	$l = sprintf "%s price %s $+{value} %s", pp_date $+{date}, map_commodity $+{commodity1}, map_commodity $+{commodity2};
 	$l =~ s/"//g;
 	print_line $depth, $l;
     } elsif ($l =~ /^$posting_RE/ || $l =~ /^(?<account>$account_RE)$/) {

--- a/tests/prices.beancount
+++ b/tests/prices.beancount
@@ -1,5 +1,9 @@
 
 
+2018-03-21 price EUR 0.87 GBP
+2018-03-21 price UR 0.015 USD
+2018-03-21 price MILESMORE4 0.01 USD
+
 2018-03-21 * "Virtual cost (@)"
   Assets:Test                10.00 EUR @ 0.90 GBP
   Equity:Opening-Balance     -9.00 GBP

--- a/tests/prices.ledger
+++ b/tests/prices.ledger
@@ -1,4 +1,8 @@
 
+P 2018-03-21 EUR 0.87 GBP
+P 2018-03-21 Chase 0.015 USD
+P 2018-03-21 "M&M4" 0.01 USD
+
 2018-03-21 * Virtual cost (@)
     Assets:Test                10.00 EUR (@) 0.90 GBP
     Equity:Opening-Balance     -9.00 GBP


### PR DESCRIPTION
Support for the price directive in ledger2beancount-txns accidentally
got broken in commit 2a9a569c  ("recognize metadata on the same line as
the posting") and I never noticed because there was no test case.