### PR TITLE
fix balance assertions

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -477,8 +477,10 @@ sub process_txn(@) {
 			$l .= " $+{at} " . replace_commodity $+{lot_price};
 		    }
 		}
+		push_line $depth, $l;
+	    } else {
+		push_line $depth, $l;
 	    }
-	    push_line $depth, $l;
 	    handle_metadata $depth+1, \%metadata_posting if exists $metadata_posting{key};
 	    push_metadata $depth + 1, $config->{auxdate_tag}, pp_date $auxdate if defined $auxdate && defined $config->{auxdate_tag};
 	} else {  # everything else

--- a/tests/balance-assertion.beancount
+++ b/tests/balance-assertion.beancount
@@ -1,0 +1,19 @@
+
+1970-01-01 open Assets:Test
+1970-01-01 open Equity:Opening-Balance
+
+1970-01-01 commodity EUR
+
+2018-03-23 * "Test 1"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-24 balance Assets:Test  10.00 EUR
+
+2018-03-24 * "Test 2"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-25 balance Assets:Test  20.00 EUR
+2018-03-25 balance Equity:Opening-Balance  -20.00 EUR
+

--- a/tests/balance-assertion.ledger
+++ b/tests/balance-assertion.ledger
@@ -1,0 +1,14 @@
+
+account Assets:Test
+account Equity:Opening-Balance
+
+commodity EUR
+
+2018-03-23 * Test 1
+    Assets:Test                        10.00 EUR = 10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-03-24 * Test 2
+    Assets:Test                        10.00 EUR = 20.00 EUR
+    Equity:Opening-Balance            -10.00 EUR = -20.00 EUR
+


### PR DESCRIPTION
Commit 67dd3f1 ("parse lot costs even when no lot prices are given")
accidentally broke balance assertions by creating invalid beancount
syntax.

Fixes #60