### PR TITLE
add option to specify configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.6"
 install:
-  - sudo apt-get install libcarp-assert-perl libdate-calc-perl libyaml-libyaml-perl libfile-basedir-perl libexperimental-perl cpanminus
+  - sudo apt-get install libcarp-assert-perl libdate-calc-perl libyaml-libyaml-perl libfile-basedir-perl libexperimental-perl libgetopt-long-descriptive-perl cpanminus
   - sudo cpanm Config::Onion
   - pip install beancount==2.0rc1
 script:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ formatting, etc.) can be preserved.
 
 ledger2beancount relies on some configuration data.  It will search for
 the config file `ledger2beancount.yml` and if that is not found for
-`$HOME/.config/ledger2beancount/config.yml`.  See the sample config
-file for the variables.
+`$HOME/.config/ledger2beancount/config.yml`.  You can also pass an
+alternative config file via `--config/-c`.  The file must end in `.yml`
+or `.yaml`.  See the sample config file for the variables you can use.
 
 
 Dependencies
@@ -26,12 +27,14 @@ ledger2beancount uses several Perl modules:
 * Config::Onion
 * Date::Calc
 * File::BaseDir
+* Getopt::Long::Descriptive
 * YAML::XS
 
 If you use Debian, you can install them with:
 
     sudo apt install libcarp-assert-perl libconfig-onion-perl \
-        libdate-calc-perl libfile-basedir-perl libyaml-libyaml-perl
+        libdate-calc-perl libfile-basedir-perl libyaml-libyaml-perl \
+        libgetopt-long-descriptive-perl
 
 
 Features

--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -15,10 +15,22 @@ use Date::Calc qw(Add_Delta_Days);
 use POSIX qw(ceil);
 use File::BaseDir qw/config_home/;
 use Config::Onion;
+use Getopt::Long::Descriptive;
 use open qw(:std :locale);
 
 
-my @config_files = ('ledger2beancount', config_home('ledger2beancount', 'config'));
+my ($opt, $usage) = describe_options(
+    "bin/ledger2beancount %o <ledger-file>",
+    [ "config|c=s", "configuration file", { default  => "ledger2beancount.yml"  } ],
+    [ "help|h",     "print usage message and exit", { shortcircuit => 1 } ],
+);
+
+print($usage->text), exit if $opt->help;
+
+my $config_file = $opt->config;
+# Config::Onion expects filename without extension
+die "Config file must end in .yml" unless $config_file =~ s/\.(yml|yaml)$//;
+my @config_files = ($config_file, config_home('ledger2beancount', 'config'));
 my $config;
 foreach my $config_file (@config_files) {
     $config = Config::Onion->load($config_file);


### PR DESCRIPTION
Allow users to specify a config file as an argument in case they
need different config files for different options.

Note that Config::Onion is weird about the name of the file.  The
file has to end in .yml or .yaml but Config::Onion expects the
filename without any extension.

Fixes #63