### PR TITLE
improve account and commodity handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,26 @@ ledger2beancount will convert ledger account declarations to beancount
 date.  The `note` is used as the `description`.
 
 ledger2beancount replaces ledger account names with valid beancount
-accounts and therefore performs the following three transformations
+accounts and therefore performs the following transformations
 automatically:
 
-1. Replaces space with dash (`Liabilities:Credit Card` becomes
-   `Liabilities:Credit-Card`)
+1. Replaces space and other invalid characters with dash
+   (`Liabilities:Credit Card` becomes `Liabilities:Credit-Card`)
 2. Replaces account names starting with lower case letters with
    upper case letters (`Assets:test` becomes `Assets:Test`)
 3. Moves digits from the beginning of the account name to the
    end (`Assets:99Ranch` becomes `Assets:Ranch99`)
+4. Ensures the first letter is a letter by replacing a non-letter
+   first character with an "X".
+5. Strips accents and umlauts because they are currently not
+   supported in beancount ([issue
+   171](https://bitbucket.org/blais/beancount/issues/171)).
 
 While these transformations lead to valid beancount account names,
 they might not be what you desire.  Therefore, you can add account
 mappings to `account_map` to map the transformed account names to
-something different.
+something different.  The mapping will work on your ledger account
+names and on the account names after the transformation.
 
 
 ### Commodities
@@ -78,7 +84,9 @@ ledger2beancount will automatically convert commodities to valid
 beancount commodities.  This involves replacing all invalid characters
 with a dash (a character allowed in beancount commodities but not in
 ledger commodities), stripping quoted commodities, making the commodity
-uppercase and limiting it to 24 characters.
+uppercase and limiting it to 24 characters.  Futhermore, the first
+character will be replaced with an "X" if it's not a letter and the
+same will be done for the last character if it's not a letter or digit.
 
 If you require a mapping between ledger and beancount commodities, you
 can use `commodity_map`.  You can use your ledger commodity names or

--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -9,6 +9,7 @@
 use strict;
 use warnings;
 use experimental 'smartmatch';
+use feature 'unicode_strings';
 
 use Carp::Assert;
 use Date::Calc qw(Add_Delta_Days);
@@ -16,6 +17,7 @@ use POSIX qw(ceil);
 use File::BaseDir qw/config_home/;
 use Config::Onion;
 use Getopt::Long::Descriptive;
+use Unicode::Normalize;
 use open qw(:std :locale);
 
 
@@ -59,11 +61,16 @@ my $txn_header_no_date_RE = qr/\s*(?<flag>$flags_RE)?(\s+\((?<code>.*?)\))?\s+(?
 my $txn_header_RE = qr/^(?<date>$date_RE)(=(?<auxdate>$date_RE))?$txn_header_no_date_RE/;
 my $txn_header_no_year_RE = qr/^(?<date>$date_no_year_RE)(=(?<auxdate>$date_no_year_RE))?$txn_header_no_date_RE/;
 my $tags_RE = qr/(?<tags>[\w:-]+)/;
-my $account_RE = qr/[A-Z].*?/;
+# An account can be pretty much anything but it has to be followed by
+# two spaces, a tab or new line (see $posting_RE).
+my $account_RE = qr/.*?/;
 my $value_RE = qr/[\d.-]+/;
-# ledger doesn't allow digits at the end (has to be a quote) but the
-# regex has to match after we strip the quote so we allow digits at end.
-my $commodity_RE = qr/[A-Za-z_"][A-Za-z0-9 !_"^&]*[A-Za-z_0-9"]/;
+# A quoted commodity ("LU0274208692") can contain anything
+# between quotes.
+my $commodity_quoted_RE = qr/(["'])(?:(?=(\\?))\g{-1}.)*?\g{-2}/;
+# An unquoted commodity may not contain certain characters
+my $commodity_unquoted_RE = qr/[^;\s0-9"'{}@]+/;
+my $commodity_RE = qr/$commodity_quoted_RE|$commodity_unquoted_RE/;
 my $amount_RE = qr/(?<num>$value_RE)\s+(?<commodity>$commodity_RE)/;
 my $comment_top_level_RE = qr/[;#%|*]\s*(?<comment>.*)/;
 my $comment_RE = qr/;\s*(?<comment>.*)/;
@@ -353,35 +360,53 @@ sub map_metadata($) {
 
 
 # map a ledger account to a beancount account
+# ledger account: can be pretty much anything, as long as it's followed
+# by two spaces, a tab or the end of the line.
+# beancount accounts: "account names begin with a capital letter and are
+# followed letters, numbers or dash (-) characters. All other characters
+# are disallowed."
 sub map_account($) {
     my ($account) = @_;
 
-    $account =~ s/ /-/g;
-    $account =~ s/:([a-z])/:\U$1\E/g;
-    $account =~ s/:(\d+)([^:]+)/:$2$1/g;
+    $account = $config->{account_map}{$account} if exists $config->{account_map}{$account};
+    $account =~ s/:(\d+)([^:]+)/:$2$1/g; # Move digits from the front to the back
+    $account =~ s/:(\p{lower})/:\U$1\E/g; # Make first letter uppercase
+    $account =~ s/:[^\p{letter}]/:X/g; # Make sure first character is a letter
+    # Work around lack of Unicode support (beancount #161)
+    $account = NFKD $account;
+    $account =~ s/\p{NonspacingMark}//g;
+    $account =~ s/[^a-zA-Z0-9:-]/-/g; # Replace disallowed characters
     $account = $config->{account_map}{$account} if exists $config->{account_map}{$account};
     return $account;
 }
 
 
 # map a ledger commodity to a beancount commodity
+# beancount commodity: up to 24 characters long, beginning with a capital
+# letter and ending with a capital letter or a number. The middle
+# characters may include "_-'."
 sub map_commodity($) {
-    my ($key) = @_;
+    my ($commodity) = @_;
 
-    return $config->{commodity_map}{$key} if exists $config->{commodity_map}{$key};
-    $key =~ s/(^")|("$)//g;
+    return $config->{commodity_map}{$commodity} if exists $config->{commodity_map}{$commodity};
+    $commodity =~ s/(^")|("$)//g;
     # Check again after removing the quote
-    return $config->{commodity_map}{$key} if exists $config->{commodity_map}{$key};
-
-    # Generate a valid beancount name
-    # Dash (-) is not valid in ledger (even with quoted commodity) but valid
-    # in beancount
-    $key =~ s/[!"^& ]/-/g;
-
-    return $config->{commodity_map}{$key} if exists $config->{commodity_map}{$key};
+    return $config->{commodity_map}{$commodity} if exists $config->{commodity_map}{$commodity};
 
     # Maxium limit for beancount commodities: 24 characters
-    return substr (uc $key, 0, 24);
+    $commodity = substr (uc $commodity, 0, 24);
+    # Work around lack of Unicode support (beancount #161)
+    $commodity = NFKD $commodity;
+    $commodity =~ s/\p{NonspacingMark}//g;
+    # Dash (-) is not valid in ledger (even with quoted commodity) but valid
+    # in beancount
+    $commodity =~ s/[^a-zA-Z0-9_'.-]/-/g; # Replace disallowed characters
+    $commodity =~ s/^[^\p{letter}]/X/g; # Make sure first character is a letter
+    $commodity =~ s/[^\p{letter}\p{number}]$/X/g; # Make sure last character is a letter or number
+
+    return $config->{commodity_map}{$commodity} if exists $config->{commodity_map}{$commodity};
+
+    return $commodity;
 }
 
 # Replace commodity in string with beancount commodity
@@ -389,7 +414,7 @@ sub replace_commodity($) {
     my ($s) = @_;
 
     if ($s =~ /$amount_RE/) {
-	$s =~ s/(\s*)$amount_RE/$1$2 @{[map_commodity($3)]}/;
+	$s =~ s/$amount_RE/$+{num} @{[map_commodity $+{commodity}]}/;
     }
     return $s;
 }
@@ -460,13 +485,11 @@ sub process_txn(@) {
 
 	    # Replace ledger account names with corresponding beancount account names
 	    my $beancount_account = map_account $account;
-	    $l =~ s/$account/$beancount_account/;
-
-	    $l = replace_commodity $l;
+	    $l =~ s/\Q$account\E/$beancount_account/;
 
 	    if ($l =~ /^$posting_RE\s*=\s*(?<assertion>$amount_RE)/) {
 		# posting with balance assertion
-		push_line $depth, $+{posting};
+		push_line $depth, replace_commodity $+{posting};
 		push_assertion $+{account}, $+{assertion};
 	    } elsif ($l =~ /^$posting_RE(\s+(?<curlyopen>\{\{?)\s*(?<lot_cost>$amount_RE)\s*(?<curlyclose>\}\}?))?\s*(\[(?<date>$date_RE)\])?\s*(\((?<lot_note>[^@].*)\))?\s*(\(?(?<at>@@?)\)?\s+(?<lot_price>$amount_RE))?/) {
 		# posting with unit price and optional lot price
@@ -509,14 +532,14 @@ sub process_txn(@) {
 			$l .= " $+{at} " . replace_commodity $+{lot_price};
 		    }
 		}
-		push_line $depth, $l;
+		push_line $depth, replace_commodity $l;
 	    } else {
-		push_line $depth, $l;
+		push_line $depth, replace_commodity $l;
 	    }
 	    handle_metadata $depth+1, \%metadata_posting if exists $metadata_posting{key};
 	    push_metadata $depth + 1, $config->{auxdate_tag}, pp_date $auxdate, 0 if defined $auxdate && defined $config->{auxdate_tag};
 	} else {  # everything else
-	    push_line $depth, $l;
+	    push_line $depth, replace_commodity $l;
 	}
     }
     print pop_txn();

--- a/tests/accounts.beancount
+++ b/tests/accounts.beancount
@@ -7,6 +7,13 @@
 1970-01-01 open Assets:Vouchers:Ranch99
 1970-01-01 open Assets:Vouchers:Ranch99:Test99
 1970-01-01 open Liabilities:Credit-Card:Test
+1970-01-01 open Assets:Vouchers:Test99
+1970-01-01 open Assets:X-DASD----------------0---ds
+1970-01-01 open Assets:Xfoo:Xbar
+1970-01-01 open Expenses:Ecole-republicaine
+1970-01-01 open Expenses:Ecole
+1970-01-01 open Assets:Crowns
+1970-01-01 open Assets:Test:I-Love-Crowns
 
 1970-01-01 commodity EUR
 
@@ -66,4 +73,32 @@
 2018-03-18 * "2 account name starting with digits"
   Assets:Vouchers:Ranch99:Test99     10.00 EUR
   Equity:Opening-Balance
+
+2018-03-18 * "Lower case after digit"
+  Assets:Vouchers:Test99             10.00 EUR
+  Equity:Opening-Balance
+
+2018-03-26 * "Interesting account name"
+  Assets:X-DASD----------------0---ds   10.00 EUR
+  Equity:Opening-Balance               -10.00 EUR
+
+2018-03-26 * "Interesting account name, mapped before conversion"
+  Assets:Crowns                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-26 * "Interesting account name, mapped after conversion"
+  Assets:Test:I-Love-Crowns            10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-26 * "Ensure first letter is upper case letter"
+  Assets:Xfoo:Xbar                   10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-26 * "Drop accents"
+  Expenses:Ecole-republicaine        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-03-26 * "Ensure first letter is upper case letter"
+  Expenses:Ecole                     10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
 

--- a/tests/accounts.ledger
+++ b/tests/accounts.ledger
@@ -7,6 +7,13 @@ account Equity:Opening balance
 account Assets:Vouchers:99Ranch
 !account Assets:Vouchers:99Ranch:99Test
 @account Liabilities:Credit Card:Test
+account Assets:Vouchers:99test
+account Assets:♚_DASD!;?@#$!%^& *"(*(0-;♚ds
+account Assets:♚foo:♚bar
+account Expenses:École républicaine
+account Expenses:école
+account Assets:♚♛♕♔
+account Assets:Test:I love ♚♛♕♔
 
 commodity EUR
 
@@ -66,4 +73,32 @@ commodity EUR
 2018-03-18 * 2 account name starting with digits
     Assets:Vouchers:99Ranch:99Test     10.00 EUR
     Equity:Opening-Balance
+
+2018-03-18 * Lower case after digit
+    Assets:Vouchers:99test             10.00 EUR
+    Equity:Opening-Balance
+
+2018-03-26 * Interesting account name
+    Assets:♚_DASD!;?@#$!%^& *"(*(0-;♚ds   10.00 EUR
+    Equity:Opening-Balance               -10.00 EUR
+
+2018-03-26 * Interesting account name, mapped before conversion
+    Assets:♚♛♕♔                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-03-26 * Interesting account name, mapped after conversion
+    Assets:Test:I love ♚♛♕♔            10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-03-26 * Ensure first letter is upper case letter
+    Assets:♚foo:♚bar                   10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-03-26 * Drop accents
+    Expenses:École républicaine        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-03-26 * Ensure first letter is upper case letter
+    Expenses:école                     10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
 

--- a/tests/commodities.beancount
+++ b/tests/commodities.beancount
@@ -23,6 +23,15 @@
 1970-01-01 commodity MR
   name: "AMEX Membership Rewards"
 
+1970-01-01 commodity KRW
+1970-01-01 commodity AUD
+1970-01-01 commodity CROWNX
+1970-01-01 commodity BAR
+1970-01-01 commodity FOO
+
+1970-01-01 commodity MOETZ
+1970-01-01 commodity MOO
+
 2018-03-17 * "Test quoted commodity"
   Assets:Test                      1 DE0002635307
   Equity:Opening-Balance          -1 DE0002635307
@@ -73,5 +82,33 @@
 
 2018-03-21 * "Commodity is too long for beancount"
   Assets:Test                          1 ANOTHERANOTHERANOTHERANO
+  Equity:Opening-Balance
+
+2018-03-26 * "Lower case"
+  Assets:Test                          1 KRW
+  Equity:Opening-Balance
+
+2018-03-26 * "Lower case at end"
+  Assets:Test                          1 AUD
+  Equity:Opening-Balance
+
+2018-03-26 * "Non-letter at end"
+  Assets:Test                          1 CROWNX
+  Equity:Opening-Balance
+
+2018-03-26 * "Umlaut in middle"
+  Assets:Test                          1 BAR
+  Equity:Opening-Balance
+
+2018-03-26 * "Umlaut at end"
+  Assets:Test                          1 FOO
+  Equity:Opening-Balance
+
+2018-03-26 * "Mapped before transformation"
+  Assets:Test                          1 MOETZ
+  Equity:Opening-Balance
+
+2018-03-26 * "Mapped after transformation"
+  Assets:Test                          1 MOO
   Equity:Opening-Balance
 

--- a/tests/commodities.ledger
+++ b/tests/commodities.ledger
@@ -24,6 +24,15 @@ commodity "M&M4"
 commodity MR
     note AMEX Membership Rewards
 
+commodity krw
+commodity Aud
+commodity Crown♛
+commodity Bär
+commodity Föö
+
+commodity Mötz
+commodity M♛O
+
 2018-03-17 * Test quoted commodity
     Assets:Test                      1 "DE0002635307"
     Equity:Opening-Balance          -1 "DE0002635307"
@@ -74,5 +83,33 @@ commodity MR
 
 2018-03-21 * Commodity is too long for beancount
     Assets:Test                          1 AnotherAnotherAnotherAnother
+    Equity:Opening-Balance
+
+2018-03-26 * Lower case
+    Assets:Test                          1 krw
+    Equity:Opening-Balance
+
+2018-03-26 * Lower case at end
+    Assets:Test                          1 Aud
+    Equity:Opening-Balance
+
+2018-03-26 * Non-letter at end
+    Assets:Test                          1 Crown♛
+    Equity:Opening-Balance
+
+2018-03-26 * Umlaut in middle
+    Assets:Test                          1 Bär
+    Equity:Opening-Balance
+
+2018-03-26 * Umlaut at end
+    Assets:Test                          1 Föö
+    Equity:Opening-Balance
+
+2018-03-26 * Mapped before transformation
+    Assets:Test                          1 Mötz
+    Equity:Opening-Balance
+
+2018-03-26 * Mapped after transformation
+    Assets:Test                          1 M♛O
     Equity:Opening-Balance
 

--- a/tests/ledger2beancount.yml
+++ b/tests/ledger2beancount.yml
@@ -20,6 +20,8 @@ payee_match:
 
 account_map:
   "Equity:Opening-balance": Equity:Opening-Balance
+  Assets:♚♛♕♔: Assets:Crowns
+  Assets:Test:I love ♚♛♕♔: Assets:Test:I-Love-Crowns
 
 # mapping of ledger commodities to valid beancount commodities
 commodity_map:
@@ -28,6 +30,8 @@ commodity_map:
   M&M2: MILESMORE2
   M-M4: MILESMORE4
   Another commodity: ANOTHER
+  Mötz: MOETZ
+  M-O: MOO
 
 # You can set the following metadata tags to an empty string if you
 # don't want the metadata to be added to beancount.


### PR DESCRIPTION
This improves the way accounts and commodities are handled.  First,
the regular expessions are much more permissive now.  Second, the
transformations should handle all required transformations, including
Unicode characters.

This fixes #68 (invalid characters in beancount accounts) and also
fixes #67 (umlauts in ledger commodities).