### PR TITLE
fix support for payee_tag and payer_tag

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -252,7 +252,6 @@ sub push_payee($) {
 sub push_line($$) {
     my ($depth, $line) = @_;
 
-    $in_postings = 1 if $line =~ /^$posting_RE/;
     push @cur_txn_lines, indent($depth, $line);
 }
 
@@ -472,6 +471,7 @@ sub process_txn(@) {
 	} elsif ($l =~ /^$comment_RE/) {  # (every other) comment
 	    push_comment $depth, $+{comment};
 	} elsif ($l =~ /^$posting_RE/ || $l =~ /^(?<account>$account_RE)$/) {
+	    $in_postings = 1;
 	    my $account = $+{account};
 	    my $auxdate = $+{auxdate};
 	    # Strip the auxdate info

--- a/tests/ledger2beancount.yml
+++ b/tests/ledger2beancount.yml
@@ -5,6 +5,8 @@ date_match: (?<year>\d{4})[/-](?<month>\d{2})[/-](?<day>\d{2})
 # mapping of ledger metadata key to corresponding beancount key
 metadata_map:
   label: bank-label
+  x-payee: payee
+  x-payer: payer
 
 # metadata tags (*after* above mapping) used for specific purposes
 payee_tag: payee

--- a/tests/payee.beancount
+++ b/tests/payee.beancount
@@ -29,3 +29,11 @@
   Assets:Test                        10.00 GBP
   Equity:Opening-Balance            -10.00 GBP
 
+2018-03-26 * "MK2" "Payee from metadata"
+  Assets:Test                        10.00 GBP
+  Equity:Opening-Balance            -10.00 GBP
+
+2018-03-26 * "Martin" "Payer from metadata"
+  Assets:Test                        10.00 GBP
+  Equity:Opening-Balance            -10.00 GBP
+

--- a/tests/payee.ledger
+++ b/tests/payee.ledger
@@ -31,3 +31,13 @@ commodity GBP
     Assets:Test                        10.00 GBP
     Equity:Opening-Balance            -10.00 GBP
 
+2018-03-26 * Payee from metadata
+    ; X-Payee: MK2
+    Assets:Test                        10.00 GBP
+    Equity:Opening-Balance            -10.00 GBP
+
+2018-03-26 * Payer from metadata
+    ; X-Payer: Martin
+    Assets:Test                        10.00 GBP
+    Equity:Opening-Balance            -10.00 GBP
+


### PR DESCRIPTION
Commit 1b715b5 ("improve account and commodity handling") broke support
for payee_tag and payer_tag.  After the change, push_line() incorrectly
identified beancount metadata as ledger postings, thinking the parsing
of postings had begun.