### PR TITLE
avoid interpreting account names as commodities

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -494,10 +494,11 @@ sub process_txn(@) {
 	    push_comment $depth, $+{comment} if $+{comment} ne "";
 	} elsif ($l =~ /^$comment_RE/) {  # (every other) comment
 	    push_comment $depth, $+{comment};
-	} elsif ($l =~ /^$posting_RE/ || $l =~ /^(?<account>$account_RE)$/) {
+	} elsif ($l =~ /^$posting_RE/) {
 	    $in_postings = 1;
 	    my $account = $+{account};
 	    my $auxdate = $+{auxdate};
+	    my $has_amount = $+{amount} ? 1 : 0;
 	    # Strip the auxdate info
 	    $l =~ s/\s*\Q$+{auxdatestrip}\E// if $+{auxdatestrip};
 
@@ -515,7 +516,7 @@ sub process_txn(@) {
 		# posting with balance assertion
 		push_line $depth, replace_commodity $+{posting};
 		push_assertion $+{account}, $+{assertion};
-	    } elsif ($l =~ /^$posting_RE(\s+(?<curlyopen>\{\{?)\s*(?<lot_cost>$amount_RE)\s*(?<curlyclose>\}\}?))?\s*(\[(?<date>$date_RE)\])?\s*(\((?<lot_note>[^@].*)\))?\s*(\(?(?<at>@@?)\)?\s+(?<lot_price>$amount_RE))?/) {
+	    } elsif ($has_amount && $l =~ /^$posting_RE(\s+(?<curlyopen>\{\{?)\s*(?<lot_cost>$amount_RE)\s*(?<curlyclose>\}\}?))?\s*(\[(?<date>$date_RE)\])?\s*(\((?<lot_note>[^@].*)\))?\s*(\(?(?<at>@@?)\)?\s+(?<lot_price>$amount_RE))?/) {
 		# posting with unit price and optional lot price
 		# XXX refactor/merge with previous regexp case
 		my $lot_info = "";
@@ -557,8 +558,10 @@ sub process_txn(@) {
 		    }
 		}
 		push_line $depth, replace_commodity $l;
-	    } else {
+	    } elsif ($has_amount) {
 		push_line $depth, replace_commodity $l;
+	    } else {
+		push_line $depth, $l;
 	    }
 	    handle_metadata $depth+1, \%metadata_posting if exists $metadata_posting{key};
 	    push_metadata $depth + 1, $config->{auxdate_tag}, pp_date $auxdate, 0 if defined $auxdate && defined $config->{auxdate_tag};

--- a/tests/accounts.beancount
+++ b/tests/accounts.beancount
@@ -14,6 +14,7 @@
 1970-01-01 open Expenses:Ecole
 1970-01-01 open Assets:Crowns
 1970-01-01 open Assets:Test:I-Love-Crowns
+1970-01-01 open Assets:Commodity-Test123
 
 1970-01-01 commodity EUR
 
@@ -101,4 +102,8 @@
 2018-03-26 * "Ensure first letter is upper case letter"
   Expenses:Ecole                     10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
+
+2018-03-27 * "Account name could be mistaken for commodity"
+  Assets:Test                        10.00 EUR
+  Assets:Commodity-Test123
 

--- a/tests/accounts.ledger
+++ b/tests/accounts.ledger
@@ -14,6 +14,7 @@ account Expenses:École républicaine
 account Expenses:école
 account Assets:♚♛♕♔
 account Assets:Test:I love ♚♛♕♔
+account Assets:Commodity-Test123
 
 commodity EUR
 
@@ -101,4 +102,8 @@ commodity EUR
 2018-03-26 * Ensure first letter is upper case letter
     Expenses:école                     10.00 EUR
     Equity:Opening-Balance            -10.00 EUR
+
+2018-03-27 * Account name could be mistaken for commodity
+    Assets:Test                        10.00 EUR
+    Assets:Commodity-Test123
 

--- a/tests/aux-date.beancount
+++ b/tests/aux-date.beancount
@@ -1,4 +1,5 @@
 
+1970-01-01 open Assets:Commodity-Test123
 1970-01-01 open Assets:Test
 1970-01-01 open Equity:Opening-Balance
 
@@ -28,5 +29,10 @@
 2018-03-18 * "Test with posting aux date after no amount"
   Assets:Test                        10.00 EUR
   Equity:Opening-Balance
+    aux-date: 2018-03-13
+
+2018-03-27 * "Account name could be mistaken for commodity"
+  Assets:Test                        10.00 EUR
+  Assets:Commodity-Test123
     aux-date: 2018-03-13
 

--- a/tests/aux-date.ledger
+++ b/tests/aux-date.ledger
@@ -1,4 +1,5 @@
 
+account Assets:Commodity-Test123
 account Assets:Test
 account Equity:Opening balance
 
@@ -23,4 +24,8 @@ commodity EUR
 2018-03-18 * Test with posting aux date after no amount
     Assets:Test                        10.00 EUR
     Equity:Opening balance                       ; [=2018-03-13]
+
+2018-03-27 * Account name could be mistaken for commodity
+    Assets:Test                        10.00 EUR
+    Assets:Commodity-Test123                     ; [=2018-03-13]
 

--- a/tests/comments.beancount
+++ b/tests/comments.beancount
@@ -1,6 +1,7 @@
 
 1970-01-01 open Assets:Test
 1970-01-01 open Equity:Opening-Balance
+1970-01-01 open Assets:Commodity-Test123
 
 1970-01-01 commodity EUR
 
@@ -45,4 +46,12 @@
     comment2"
   Assets:Test                        10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
+
+2018-03-27 * "Account name could be mistaken for commodity"
+  Assets:Test                        10.00 EUR
+  Assets:Commodity-Test123       ; comment
+
+2018-03-27 * "Account name could be mistaken for commodity"
+  Assets:Test                        10.00 EUR
+  Assets:Commodity-Test123  ; comment
 

--- a/tests/comments.ledger
+++ b/tests/comments.ledger
@@ -1,6 +1,7 @@
 
 account Assets:Test
 account Equity:Opening-Balance
+account Assets:Commodity-Test123
 
 commodity EUR
 
@@ -54,4 +55,12 @@ end comment
     ; comment2
     Assets:Test                        10.00 EUR
     Equity:Opening-Balance            -10.00 EUR
+
+2018-03-27 * Account name could be mistaken for commodity
+    Assets:Test                        10.00 EUR
+    Assets:Commodity-Test123       ; comment
+
+2018-03-27 * Account name could be mistaken for commodity
+    Assets:Test                        10.00 EUR
+    Assets:Commodity-Test123  ; comment
 


### PR DESCRIPTION
Since commodities are allowed to be placed in front of amounts (e.g.
-EUR10), it's easy to think that parts of the account name is a
commodity.  Avoid that by making sure we only do commodity replacements
if there's an ammount.