### PR TITLE
allow account names starting with a number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
 install:
   - sudo apt-get install libcarp-assert-perl libdate-calc-perl libyaml-libyaml-perl libfile-basedir-perl libexperimental-perl libgetopt-long-descriptive-perl cpanminus
   - sudo cpanm Config::Onion
-  - pip install beancount==2.0rc1
+  - pip install beancount==2.0
 script:
   - make test

--- a/README.md
+++ b/README.md
@@ -82,13 +82,11 @@ automatically:
    (`Liabilities:Credit Card` becomes `Liabilities:Credit-Card`)
 2. Replaces account names starting with lower case letters with
    upper case letters (`Assets:test` becomes `Assets:Test`)
-3. Moves digits from the beginning of the account name to the
-   end (`Assets:99Ranch` becomes `Assets:Ranch99`)
-4. Ensures the first letter is a letter by replacing a non-letter
-   first character with an "X".
-5. Strips accents and umlauts because they are currently not
+3. Strips accents and umlauts because they are currently not
    supported in beancount ([issue
    171](https://bitbucket.org/blais/beancount/issues/171)).
+4. Ensures the first letter is a letter or number by replacing
+   a non-letter first character with an "X".
 
 While these transformations lead to valid beancount account names,
 they might not be what you desire.  Therefore, you can add account

--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -397,16 +397,15 @@ sub map_metadata($) {
 # map a ledger account to a beancount account
 # ledger account: can be pretty much anything, as long as it's followed
 # by two spaces, a tab or the end of the line.
-# beancount accounts: "account names begin with a capital letter and are
-# followed letters, numbers or dash (-) characters. All other characters
-# are disallowed."
+# beancount accounts: "account names begin with a capital letter or a
+# number and are followed letters, numbers or dash (-) characters. All
+# other characters are disallowed."
 sub map_account($) {
     my ($account) = @_;
 
     $account = $config->{account_map}{$account} if exists $config->{account_map}{$account};
-    $account =~ s/:(\d+)([^:]+)/:$2$1/g; # Move digits from the front to the back
     $account =~ s/:(\p{lower})/:\U$1\E/g; # Make first letter uppercase
-    $account =~ s/:[^\p{letter}]/:X/g; # Make sure first character is a letter
+    $account =~ s/:[^\p{letter}\p{number}]/:X/g; # Make sure first character is a letter or number
     # Work around lack of Unicode support (beancount #161)
     $account = NFKD $account;
     $account =~ s/\p{NonspacingMark}//g;

--- a/tests/accounts.beancount
+++ b/tests/accounts.beancount
@@ -4,10 +4,10 @@
 
 1970-01-01 open Equity:Opening-Balance
   description: "opening balance..."
-1970-01-01 open Assets:Vouchers:Ranch99
-1970-01-01 open Assets:Vouchers:Ranch99:Test99
+1970-01-01 open Assets:Vouchers:99Ranch
+1970-01-01 open Assets:Vouchers:99Ranch:99Test
 1970-01-01 open Liabilities:Credit-Card:Test
-1970-01-01 open Assets:Vouchers:Test99
+1970-01-01 open Assets:Vouchers:99test
 1970-01-01 open Assets:X-DASD----------------0---ds
 1970-01-01 open Assets:Xfoo:Xbar
 1970-01-01 open Expenses:Ecole-republicaine
@@ -68,15 +68,15 @@
   Equity:Opening-Balance
 
 2018-03-18 * "Account name starting with digits"
-  Assets:Vouchers:Ranch99            10.00 EUR
+  Assets:Vouchers:99Ranch            10.00 EUR
   Equity:Opening-Balance
 
 2018-03-18 * "2 account name starting with digits"
-  Assets:Vouchers:Ranch99:Test99     10.00 EUR
+  Assets:Vouchers:99Ranch:99Test     10.00 EUR
   Equity:Opening-Balance
 
 2018-03-18 * "Lower case after digit"
-  Assets:Vouchers:Test99             10.00 EUR
+  Assets:Vouchers:99test             10.00 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Interesting account name"

--- a/tests/amounts-decimal-comma.beancount
+++ b/tests/amounts-decimal-comma.beancount
@@ -1,19 +1,19 @@
 ; Config: amounts-decimal-comma.yml
 
-1970-01-01 open Assets:Test99:Test99
+1970-01-01 open Assets:99Test:Test99
 1970-01-01 open Equity:Opening-Balance
 
 1970-01-01 commodity EUR
 
 2018-03-26 * "Decimal comma"
-  Assets:Test99:Test99               10.12 EUR
+  Assets:99Test:Test99               10.12 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Decimal comma, with thousand separator"
-  Assets:Test99:Test99            1000.00 EUR
+  Assets:99Test:Test99            1000.00 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Decimal comma, with thousand separator"
-  Assets:Test99:Test99            1000.00 EUR
+  Assets:99Test:Test99            1000.00 EUR
   Equity:Opening-Balance
 

--- a/tests/amounts.beancount
+++ b/tests/amounts.beancount
@@ -1,5 +1,5 @@
 
-1970-01-01 open Assets:Test99:Test99
+1970-01-01 open Assets:99Test:Test99
 1970-01-01 open Assets:Test1
 1970-01-01 open Assets:Test2
 1970-01-01 open Equity:Opening-Balance
@@ -9,83 +9,83 @@
 1970-01-01 commodity USD
 
 2018-03-26 * "Commodity after amount"
-  Assets:Test99:Test99                   1 EUR
+  Assets:99Test:Test99                   1 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity after amount, no space"
-  Assets:Test99:Test99                    1 EUR
+  Assets:99Test:Test99                    1 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity before amount"
-  Assets:Test99:Test99                   1 EUR
+  Assets:99Test:Test99                   1 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity before amount, no space"
-  Assets:Test99:Test99              1000.00 EUR
+  Assets:99Test:Test99              1000.00 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity after amount, negative"
-  Assets:Test99:Test99                  -1 EUR
+  Assets:99Test:Test99                  -1 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity after amount, negative, no space"
-  Assets:Test99:Test99                   -1 EUR
+  Assets:99Test:Test99                   -1 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity before amount, negative"
-  Assets:Test99:Test99                  -3 EUR
+  Assets:99Test:Test99                  -3 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity before amount, negative"
-  Assets:Test99:Test99                  -2 EUR
+  Assets:99Test:Test99                  -2 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity symbol after amount"
-  Assets:Test99:Test99                    100 USD
+  Assets:99Test:Test99                    100 USD
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity symbol after amount, negative"
-  Assets:Test99:Test99                     -1 USD
+  Assets:99Test:Test99                     -1 USD
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity symbol before amount"
-  Assets:Test99:Test99                      1 USD
+  Assets:99Test:Test99                      1 USD
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity symbol before amount, negative"
-  Assets:Test99:Test99                     -1 USD
+  Assets:99Test:Test99                     -1 USD
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity symbol after amount, with space"
-  Assets:Test99:Test99                     1 USD
+  Assets:99Test:Test99                     1 USD
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity symbol before amount, with space"
-  Assets:Test99:Test99                     1 USD
+  Assets:99Test:Test99                     1 USD
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity symbol after amount, negative, with space"
-  Assets:Test99:Test99                    -1 USD
+  Assets:99Test:Test99                    -1 USD
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity symbol before amount, negative"
-  Assets:Test99:Test99                    -1 USD
+  Assets:99Test:Test99                    -1 USD
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity after amount, comma"
-  Assets:Test99:Test99               1,000 EUR
+  Assets:99Test:Test99               1,000 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity before amount, comma"
-  Assets:Test99:Test99            1,000.00 EUR
+  Assets:99Test:Test99            1,000.00 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity before amount, comma, no space"
-  Assets:Test99:Test99             1,000.00 EUR
+  Assets:99Test:Test99             1,000.00 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Commodity before amount, comma, one million"
-  Assets:Test99:Test99        1,000,000.00 EUR
+  Assets:99Test:Test99        1,000,000.00 EUR
   Equity:Opening-Balance
 
 2018-03-26 * "Simple inline math"


### PR DESCRIPTION
As of beancount 2.0.0, account names are allowed to start with a
number.

Fixes #72