### PR TITLE
ensure ucfirst account names, even for the account type

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -404,7 +404,7 @@ sub map_account($) {
     my ($account) = @_;
 
     $account = $config->{account_map}{$account} if exists $config->{account_map}{$account};
-    $account =~ s/:(\p{lower})/:\U$1\E/g; # Make first letter uppercase
+    $account =~ s/(^|:)(\p{lower})/$1\U$2\E/g; # Make first letter uppercase
     $account =~ s/:[^\p{letter}\p{number}]/:X/g; # Make sure first character is a letter or number
     # Work around lack of Unicode support (beancount #161)
     $account = NFKD $account;

--- a/tests/accounts.beancount
+++ b/tests/accounts.beancount
@@ -17,6 +17,7 @@
 1970-01-01 open Assets:Crowns
 1970-01-01 open Assets:Test:I-Love-Crowns
 1970-01-01 open Assets:Commodity-Test123
+1970-01-01 open Expenses:Purchase
 
 1970-01-01 commodity EUR
 
@@ -108,4 +109,8 @@
 2018-03-27 * "Account name could be mistaken for commodity"
   Assets:Test                        10.00 EUR
   Assets:Commodity-Test123
+
+2018-03-28 * "all lower case account names"
+  Expenses:Purchase                  10.00 EUR
+  Assets:Test
 

--- a/tests/accounts.ledger
+++ b/tests/accounts.ledger
@@ -17,6 +17,7 @@ account Expenses:école
 account Assets:♚♛♕♔
 account Assets:Test:I love ♚♛♕♔
 account Assets:Commodity-Test123
+account expenses:purchase
 
 commodity EUR
 
@@ -108,4 +109,8 @@ commodity EUR
 2018-03-27 * Account name could be mistaken for commodity
     Assets:Test                        10.00 EUR
     Assets:Commodity-Test123
+
+2018-03-28 * all lower case account names
+    expenses:purchase                  10.00 EUR
+    assets:test
 


### PR DESCRIPTION
We made sure all account components had an upper case character
apart from the first one.

Fixes #80