### PR TITLE
handle block comments without indentation correctly

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -751,12 +751,15 @@ while (@input) {
     } elsif ($l =~ /^[!@]?(bucket|A)\s+(.*)/) {  # bucket
 	$ledger_bucket = $2;
     } elsif ($l =~ /^[!@]?(comment|test)/) {  # block comment
-	@stanza = read_stanza \@input;
-	assert $input[0] =~ /^end/;
-	shift @input;
-	foreach $l (@stanza) {
-	    ($depth, $l) = strip_indentation $l;
-	    print_comment_top_level $depth-1, $l;
+	$l = shift @input;
+	# block comments may or may not be indented.  If the first line has
+	# indentation, strip the same indentation, from all other comments.
+	my $strip_indent = $l =~ /^(\h+)/ ? $1 : "";
+	while ($l !~ /^end\s+(comment|test)/) {
+	    chomp $l;
+	    $l =~ s/^$strip_indent//;
+	    print_comment_top_level $depth, $l;
+	    $l = shift @input;
 	}
     } elsif ($l =~ /^[!@]?define/) {  # define
 	print_warning_once "The `define` directive is not supported";

--- a/tests/comments.beancount
+++ b/tests/comments.beancount
@@ -8,14 +8,22 @@
 ; This is a block comment
 ; Second line
 
-; Comment with end, not end comment
+; Comment without indentation
 ; Second line
 
 ; Another comment
 
+; test can be ended with end comment
+
+; comment can be ended with end test
+
 ; This is another block comment
 
-; This is yet another block comment
+; No indentation, followed by
+;     indentation.
+
+; Indentation, followed by
+; no indentation.
 
 ; This is a single line comment,
 ; and this,

--- a/tests/comments.ledger
+++ b/tests/comments.ledger
@@ -11,12 +11,20 @@ comment
 end comment
 
 comment
-    Comment with end, not end comment
-    Second line
-end
+Comment without indentation
+Second line
+end comment
 
 test
     Another comment
+end test
+
+test
+    test can be ended with end comment
+end comment
+
+comment
+    comment can be ended with end test
 end test
 
 !comment
@@ -24,7 +32,13 @@ end test
 end comment
 
 @comment
-    This is yet another block comment
+No indentation, followed by
+    indentation.
+end comment
+
+@comment
+    Indentation, followed by
+no indentation.
 end comment
 
 ; This is a single line comment,


### PR DESCRIPTION
The example for block comments in the ledger manual suggests that such
comments have to be indented but this is not the case.  Something like
this is allowed in ledger:
```
comment
foo bar
end comment
```
The only requirement for block comments appears to be that they are
terminated by "end comment" or "end test" (regardless of whether they
were started with "comment" or "test").  Just "end", which I assumed
was allowed, is now valid, and neither are "!end comment" or `"@end
comment"`.

Fixes #98