### PR TITLE
improve handling of inline math

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -68,12 +68,12 @@ my $tags_RE = qr/(?<tags>[\w:-]+)/;
 # two spaces, a tab or new line (see $posting_RE).
 my $account_RE = qr/[^\s]([^\t](?!  )(?!\)  )(?!\]  ))*.?/;
 my $value_RE = qr/[\d.,]+/;
-my $value_exp_RE = qr/$value_RE(\s*[\/*+-]\s*$value_RE)?/;
+my $value_exp_RE = qr/$value_RE([\h*\/+-]*$value_RE)?/;
 # A quoted commodity ("LU0274208692") can contain anything
 # between quotes.
 my $commodity_quoted_RE = qr/(["'])(?:(?=(\\?))\g{-1}.)*?\g{-2}/;
 # An unquoted commodity may not contain certain characters
-my $commodity_unquoted_RE = qr/(?!-)[^;\s0-9)("'{}@]+/;
+my $commodity_unquoted_RE = qr/(?!-)[^;\s0-9)("'{}@*\/+-]+/;
 my $commodity_RE = qr/$commodity_quoted_RE|$commodity_unquoted_RE/;
 # Ledger supports three different amount formats:
 # [minus] amount commodity

--- a/tests/amounts.beancount
+++ b/tests/amounts.beancount
@@ -3,6 +3,13 @@
 ;   - Collision for commodity "USD": $, USD
 ;----------------------------------------------------------------------
 
+1970-01-01 open Assets:Current
+1970-01-01 open Assets:Receivable
+1970-01-01 open Assets:Rewards
+1970-01-01 open Expenses:Housing:Rent
+1970-01-01 open Expenses:Travel:Airfare
+1970-01-01 open Liabilities:BA
+1970-01-01 commodity AVIOS
 
 1970-01-01 open Assets:99Test:Test99
 1970-01-01 open Assets:Test1
@@ -116,4 +123,15 @@
 2018-03-26 * "Simple inline math"
   Assets:Test1     44.06 USD @ (1 / 1.362) GBP
   Assets:Test2                      -32.35 GBP
+
+2018-04-10 * "Inline math: negative amounts"
+  Expenses:Travel:Airfare      (2 * 15.00) GBP
+  Expenses:Travel:Airfare       (2*4500) AVIOS
+  Assets:Rewards               (2*-4500) AVIOS
+  Liabilities:BA              (2 * -15.00) GBP
+
+2018-04-10 * "Inline math"
+  Expenses:Housing:Rent         (550.00/2) GBP
+  Assets:Receivable             (550.00/2) GBP
+  Assets:Current                   -550.00 GBP
 

--- a/tests/amounts.ledger
+++ b/tests/amounts.ledger
@@ -112,3 +112,14 @@ commodity $
     Assets:Test1     44.06 USD @ (1 / 1.362 GBP)
     Assets:Test2                      -32.35 GBP
 
+2018-04-10 * Inline math: negative amounts
+    Expenses:Travel:Airfare      (2 * 15.00 GBP)
+    Expenses:Travel:Airfare       (2*4500 Avios)
+    Assets:Rewards               (2*-4500 Avios)
+    Liabilities:BA              (2 * -15.00 GBP)
+
+2018-04-10 * Inline math
+    Expenses:Housing:Rent         (550.00/2 GBP)
+    Assets:Receivable             (550.00/2 GBP)
+    Assets:Current                   -550.00 GBP
+


### PR DESCRIPTION
Improve the handling of inline math by tightening the regex for
unquoted commodities and allowing more characters for inline math.

Fixes issue #102