### PR TITLE
allow a beancount header to be embedded into the converted file

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -902,17 +902,12 @@ if (@conversion_notes) {
 }
 
 print "option \"operating_currency\" \"$_\"\n" foreach @{$config->{operating_currencies}};
-# (due to a current beancount limitation, options
-# and plugins must be in the top-level file)
-print "include \"$_\"\n" foreach @{$config->{includes}};
 
-if (defined $config->{plugins}) {
-    print <<'EOT';
-
-; plugins listed here because they don't work if declared in included files
-; see: https://bitbucket.org/blais/beancount/issues/147
-EOT
-    print "plugin \"$_\"\n" foreach @{$config->{plugins}};
+if ($config->{beancount_header}) {
+    open my $beancount_header, $config->{beancount_header} or
+	die "Can't file beancount header: $config->{beancount_header}";
+    print foreach <$beancount_header>;
+    close $beancount_header;
 }
 
 if ($config->{automatic_declarations}) {

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -75,6 +75,13 @@ ledger files:
   You have to set this if you use commodity codes like `€` or `£` (to
   map them to `EUR` and `GBP`, respectively).
 
+Additionally, these options are useful to configure beancount:
+
+* `operating_currencies`: a list of the currencies you frequently use.
+* `beancount_header`: a file which is embedded at the beginning of
+   the converted beancount file which can include beancount `option`
+   statements, `plugin` directives, `query` information and more.
+
 Other variables can be set to use various functionality offered by
 ledger2beancount.  Please read the [section on features](#features)
 to learn about these variables.

--- a/ledger2beancount.yml
+++ b/ledger2beancount.yml
@@ -16,6 +16,12 @@ ledger_indent: 4
 operating_currencies:
   - EUR
 
+# You can specify a file which serves as a beancount "header", i.e.
+# it's put at the beginning of the converted beancount file.  You can
+# specify options for beancount, such as `option "title"`, define
+# `plugin` directives or beancount `query` information.
+#beancount_header:
+
 # emit account and commodity declares
 # (Note: thee declarations done in ledger via `account` and
 # `commodity` are always converted.  If this option is true,

--- a/tests/accounts.beancount
+++ b/tests/accounts.beancount
@@ -6,6 +6,9 @@
 ;   - Collision for account "Liabilities:Credit-Card:Test": Liabilities:Credit Card:Test, Liabilities:credit Card:test
 ;----------------------------------------------------------------------
 
+
+option "title" "Test account names"
+
 1970-01-01 open Assets:Collision
 
 1970-01-01 open Assets:Test

--- a/tests/accounts.header
+++ b/tests/accounts.header
@@ -1,0 +1,3 @@
+
+option "title" "Test account names"
+

--- a/tests/accounts.yml
+++ b/tests/accounts.yml
@@ -1,0 +1,10 @@
+
+beancount_header: accounts.header
+
+account_map:
+  Assets:♚♛♕♔: Assets:Crowns
+  Assets:Test:I love ♚♛♕♔: Assets:Test:I-Love-Crowns
+  Assets:Coll1: Assets:Collision
+  Assets:Coll2: Assets:Collision
+  Equity:Opening-balance: Equity:Opening-Balance
+

--- a/tests/ledger2beancount.yml
+++ b/tests/ledger2beancount.yml
@@ -23,10 +23,6 @@ payee_match:
 
 account_map:
   "Equity:Opening-balance": Equity:Opening-Balance
-  Assets:♚♛♕♔: Assets:Crowns
-  Assets:Test:I love ♚♛♕♔: Assets:Test:I-Love-Crowns
-  Assets:Coll1: Assets:Collision
-  Assets:Coll2: Assets:Collision
 
 # mapping of ledger commodities to valid beancount commodities
 commodity_map:


### PR DESCRIPTION
Instead of giving users the ability to define plugins they'd like
to be loaded, make it more generic and allow a beancount header
file to be embedded into the converted file, so users can specify
whatever option they want.

Fixes #100