### PR TITLE
add conversion note when something is renamed

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -882,6 +882,28 @@ while (@input) {
     }
 }
 
+# Check for renames
+foreach (sort keys %ledger_accounts) {
+    my $map = map_account $_;
+    if ($_ ne $map && !($map ~~ [values %{$config->{account_map}}])) {
+        print_warning "Account $_ renamed to $map";
+    }
+}
+
+foreach (sort keys %ledger_commodities) {
+    my $map = map_commodity $_;
+    if ($_ ne $map && $_ ne qq("$map") && !($map ~~ [values %{$config->{commodity_map}}])) {
+        print_warning "Commodity $_ renamed to $map";
+    }
+}
+
+foreach (sort keys %ledger_metadata) {
+    my $map = map_metadata $_;
+    if ($_ ne $map && !($map ~~ [values %{$config->{metadata_map}}])) {
+        print_warning "Metadata key $_ renamed to $map";
+    }
+}
+
 # Check for collisions
 my %mapped_accounts;
 foreach (keys %ledger_accounts) {

--- a/tests/accounts.beancount
+++ b/tests/accounts.beancount
@@ -1,5 +1,14 @@
 ;----------------------------------------------------------------------
 ; ledger2beancount conversion notes:
+;   - Account Assets:test renamed to Assets:Test
+;   - Account Assets:♚_DASD!;?@#$!%^& *"(*(0-;♚ds renamed to Assets:X-DASD----------------0---ds
+;   - Account Assets:♚foo:♚bar renamed to Assets:Xfoo:Xbar
+;   - Account Expenses:École républicaine renamed to Expenses:Ecole-republicaine
+;   - Account Expenses:école renamed to Expenses:Ecole
+;   - Account Liabilities:Credit Card:Test renamed to Liabilities:Credit-Card:Test
+;   - Account Liabilities:credit Card:test renamed to Liabilities:Credit-Card:Test
+;   - Account assets:test renamed to Assets:Test
+;   - Account expenses:purchase renamed to Expenses:Purchase
 ;   - Collision for account "Assets:Collision": Assets:Coll1, Assets:Coll2
 ;   - Collision for account "Assets:Test": Assets:Test, Assets:test, assets:test
 ;   - Collision for account "Equity:Opening-Balance": Equity:Opening balance, Equity:Opening-Balance

--- a/tests/amounts.beancount
+++ b/tests/amounts.beancount
@@ -1,5 +1,6 @@
 ;----------------------------------------------------------------------
 ; ledger2beancount conversion notes:
+;   - Commodity Avios renamed to AVIOS
 ;   - Collision for commodity "USD": $, USD
 ;----------------------------------------------------------------------
 

--- a/tests/commodities.beancount
+++ b/tests/commodities.beancount
@@ -1,5 +1,15 @@
 ;----------------------------------------------------------------------
 ; ledger2beancount conversion notes:
+;   - Commodity "A commodity" renamed to A-COMMODITY
+;   - Commodity "M&M3" renamed to M-M3
+;   - Commodity AnotherAnotherAnotherAnother renamed to ANOTHERANOTHERANOTHERANO
+;   - Commodity Aud renamed to AUD
+;   - Commodity Bär renamed to BAR
+;   - Commodity Crown♛ renamed to CROWNX
+;   - Commodity Föö renamed to FOO
+;   - Commodity Gandi renamed to GANDI
+;   - Commodity KrisFlyer renamed to KRISFLYER
+;   - Commodity krw renamed to KRW
 ;   - Collision for commodity "COLLISION": COLLA, COLLB
 ;----------------------------------------------------------------------
 

--- a/tests/dates.beancount
+++ b/tests/dates.beancount
@@ -1,3 +1,8 @@
+;----------------------------------------------------------------------
+; ledger2beancount conversion notes:
+;   - Metadata key Date renamed to date
+;----------------------------------------------------------------------
+
 
 1970-01-01 open Assets:Test
 1970-01-01 open Equity:Opening-Balance

--- a/tests/lots.beancount
+++ b/tests/lots.beancount
@@ -1,3 +1,8 @@
+;----------------------------------------------------------------------
+; ledger2beancount conversion notes:
+;   - Commodity XXXx renamed to XXXX
+;----------------------------------------------------------------------
+
 
 1970-01-01 open Assets:Test
 1970-01-01 open Equity:Opening-Balance

--- a/tests/metadata.beancount
+++ b/tests/metadata.beancount
@@ -1,5 +1,14 @@
 ;----------------------------------------------------------------------
 ; ledger2beancount conversion notes:
+;   - Metadata key 2012 renamed to x2012
+;   - Metadata key 2012foo renamed to x2012foo
+;   - Metadata key Date renamed to date
+;   - Metadata key Invoice renamed to invoice
+;   - Metadata key TEST1234TEST renamed to tEST1234TEST
+;   - Metadata key Trip renamed to trip
+;   - Metadata key test:test renamed to test-test
+;   - Metadata key test♔ renamed to test-
+;   - Metadata key test♚ renamed to test-
 ;   - Collision for metadata "test-": test♔, test♚
 ;----------------------------------------------------------------------
 


### PR DESCRIPTION
Add a conversion note when an account, commodity or metadata key is
renamed by ledger2beancount.  While this can be fairly noisy, it's
good to show all automatic renames so users can check if they are
happy with the result.  If they want to decrease the noise, they can
add an appropriate mapping to one of the `_map` configs.