### PR TITLE
Preserve comment markers

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -83,7 +83,7 @@ my $amount_cmn_RE = qr/(?<commodity>$commodity_RE)\s*(?<minus>-?)(?<num>$value_e
 # [minus] commodity amount
 my $amount_mcn_RE = qr/(?<minus>-?)(?<commodity>$commodity_RE)\s*(?<num>$value_exp_RE)/; # -EUR 10.00
 my $amount_RE = qr/(?<inline_math>\(?)($amount_mnc_RE|$amount_cmn_RE|$amount_mcn_RE)(\)?)/;
-my $comment_top_level_RE = qr/^[;#%|*]\s?(?<comment>.*)/;
+my $comment_top_level_RE = qr/[;#%|*]\s?(?<comment>.*)/;
 my $comment_RE = qr/;\s*(?<comment>.*)/;
 my $metadata_RE = qr/;\s*(?<key>[^\h:][^\h]*?):(?<typed>:)?\s+(?<value>.*)/;
 my $posting_RE = qr/(?<posting>((?<flag>$flags_RE)\s+)?(?<virtual>[(\[]\s?)?(?<account>$account_RE)(  |\t|$|\)|\])\s*(?<amount>$amount_RE)?(?<auxdatestrip>\s*;\s*\[=(?<auxdate>$date_RE)\])?)/;
@@ -736,8 +736,13 @@ while (@input) {
     my @stanza;
     if ($l =~ /^[!@]?include\s+(?<filename>.*)\.ledger/) {  # include
 	print_line $depth, "include \"$+{filename}.beancount\"";
-    } elsif ($l =~ /$comment_top_level_RE/) {
-	print_comment_top_level $depth, $+{comment};
+    } elsif ($l =~ /^$comment_top_level_RE/) {
+	# beancount issue #282
+	if ($l =~ /^\|\s?(?<comment>.*)/) {
+	    print_comment_top_level $depth, $+{comment};
+	} else {
+	    print_line $depth, $l;
+	}
     } elsif ($l =~ /^[!@]?(?<type>alias)\s+(?<account>$account_RE)\s*=\s*(?<val>.*)/) {  # alias
 	$ledger_alias{$+{account}} = map_account_apply $+{val};
     } elsif ($l =~ /^[!@]?apply\s+(?<type>account)\s+(?<val>.*)/) {  # apply account

--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -83,7 +83,7 @@ my $amount_cmn_RE = qr/(?<commodity>$commodity_RE)\s*(?<minus>-?)(?<num>$value_e
 # [minus] commodity amount
 my $amount_mcn_RE = qr/(?<minus>-?)(?<commodity>$commodity_RE)\s*(?<num>$value_exp_RE)/; # -EUR 10.00
 my $amount_RE = qr/(?<inline_math>\(?)($amount_mnc_RE|$amount_cmn_RE|$amount_mcn_RE)(\)?)/;
-my $comment_top_level_RE = qr/[;#%|*]\s*(?<comment>.*)/;
+my $comment_top_level_RE = qr/^[;#%|*]\s?(?<comment>.*)/;
 my $comment_RE = qr/;\s*(?<comment>.*)/;
 my $metadata_RE = qr/;\s*(?<key>[^\h:][^\h]*?):(?<typed>:)?\s+(?<value>.*)/;
 my $posting_RE = qr/(?<posting>((?<flag>$flags_RE)\s+)?(?<virtual>[(\[]\s?)?(?<account>$account_RE)(  |\t|$|\)|\])\s*(?<amount>$amount_RE)?(?<auxdatestrip>\s*;\s*\[=(?<auxdate>$date_RE)\])?)/;
@@ -736,7 +736,7 @@ while (@input) {
     my @stanza;
     if ($l =~ /^[!@]?include\s+(?<filename>.*)\.ledger/) {  # include
 	print_line $depth, "include \"$+{filename}.beancount\"";
-    } elsif ($l =~ /^$comment_top_level_RE/) {
+    } elsif ($l =~ /$comment_top_level_RE/) {
 	print_comment_top_level $depth, $+{comment};
     } elsif ($l =~ /^[!@]?(?<type>alias)\s+(?<account>$account_RE)\s*=\s*(?<val>.*)/) {  # alias
 	$ledger_alias{$+{account}} = map_account_apply $+{val};

--- a/tests/comments.beancount
+++ b/tests/comments.beancount
@@ -26,10 +26,10 @@
 ; no indentation.
 
 ; This is a single line comment,
-;  and this,
-;   and this,
+#  and this,
+%   and this,
 ;    and this,
-;     and this.
+*     and this.
 
 ; This is a comment
 ; Test: not a tag

--- a/tests/comments.beancount
+++ b/tests/comments.beancount
@@ -26,10 +26,10 @@
 ; no indentation.
 
 ; This is a single line comment,
-; and this,
-; and this,
-; and this,
-; and this.
+;  and this,
+;   and this,
+;    and this,
+;     and this.
 
 ; This is a comment
 ; Test: not a tag

--- a/tests/tags-as-metadata.beancount
+++ b/tests/tags-as-metadata.beancount
@@ -11,10 +11,10 @@
 
 ; See issue #3
 ; 2018-03-17 * Tag on transaction, split over two lines
-; ; :foo:bar:baz:
-; ; :second:
-; Assets:Test                        10.00 EUR
-; Equity:Opening-Balance            -10.00 EUR
+;    ; :foo:bar:baz:
+;    ; :second:
+;    Assets:Test                        10.00 EUR
+;    Equity:Opening-Balance            -10.00 EUR
 
 2018-03-17 * "Tag on transaction, one converted to a link"
   tags: "foo, bar, baz"

--- a/tests/tags-as-metadata.beancount
+++ b/tests/tags-as-metadata.beancount
@@ -10,7 +10,7 @@
   Equity:Opening-Balance            -10.00 EUR
 
 ; See issue #3
-; 2018-03-17 * Tag on transaction, split over two lines
+;2018-03-17 * Tag on transaction, split over two lines
 ;    ; :foo:bar:baz:
 ;    ; :second:
 ;    Assets:Test                        10.00 EUR


### PR DESCRIPTION
 I assumed that comments in beancount have to start with a semicolon  while ledger allows different markers for top level comments.  Then  I noticed people using `*` in beancount, which is used as a section  marker in Emacs.  The beancount language syntax says "Any line that  does not begin as a valid Beancount syntax directive (e.g.  with a  date) is silently ignored."
 
 Therefore, keep the original comment markers from ledger.  Special  case pipe (|) due to beancount issue #282
