### PR TITLE
keep whitespace intact when replacing account names

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -488,6 +488,35 @@ sub map_account($) {
 }
 
 
+# Replace ledger account names with corresponding beancount account names
+# while trying to keep the whitespace intact by padding where necessary.
+sub replace_account($) {
+    my ($l) = @_;
+
+    if ($l =~ /^$posting_RE/) {
+	my $old = $+{account};
+	my $new = map_account $old;
+	if ($l !~ s/\Q$old\E$/$new/) {
+	    if (length($new) <= length($old)) {
+		$new .= " "x abs(length($new) - length($old));
+		$l =~ s/\Q$old\E/$new/;
+	    } else {
+		my $orig_old = $old;
+		$old .= " "x (length($new) - length($old));
+		# Ensure there are two spaces or a tab after the account name
+		$l =~ s/\Q$old\E  /$new  /;
+		$l =~ s/\Q$old\E\t/$new\t/;
+		# We can't preserve space
+		$l =~ s/\Q$orig_old\E/$new/;
+	    }
+	}
+	return $l;
+    } else {
+	die "Not a posting: $l";
+    }
+}
+
+
 # map a ledger commodity to a beancount commodity
 # beancount commodity: up to 24 characters long, beginning with a capital
 # letter and ending with a capital letter or a number. The middle
@@ -618,7 +647,7 @@ sub process_txn(@) {
 		    next;
 		}
 		if ($config->{convert_virtual}) {
-		    $l =~ s/\Q[$account]\E/$account/; # Make them real
+		    $l =~ s/\Q[$account]\E/$account  /; # Make them real
 		} else {
 		    print_warning_once "Virtual posting in bracket ignored (see convert_virtual option)";
 		    next;
@@ -636,8 +665,7 @@ sub process_txn(@) {
 		%metadata_posting = %+;
 	    }
 
-	    # Replace ledger account names with corresponding beancount account names
-	    $l =~ s/\Q$account\E/@{[map_account $account]}/;
+	    $l = replace_account $l;
 
 	    if ($l =~ /^$posting_RE\s*=\s*(?<assertion>$amount_RE)/) {
 		# posting with balance assertion

--- a/tests/accounts.beancount
+++ b/tests/accounts.beancount
@@ -18,7 +18,11 @@
 
 option "title" "Test account names"
 
+1970-01-01 open Assets:A
+1970-01-01 open Assets:Bash
 1970-01-01 open Assets:Collision
+1970-01-01 open Assets:MuchLonger
+1970-01-01 open Assets:Short
 
 1970-01-01 open Assets:Test
   description: "Test account"
@@ -108,11 +112,11 @@ option "title" "Test account names"
   Equity:Opening-Balance               -10.00 EUR
 
 2018-03-26 * "Interesting account name, mapped before conversion"
-  Assets:Crowns                        10.00 EUR
+  Assets:Crowns                      10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
 
 2018-03-26 * "Interesting account name, mapped after conversion"
-  Assets:Test:I-Love-Crowns            10.00 EUR
+  Assets:Test:I-Love-Crowns          10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
 
 2018-03-26 * "Ensure first letter is upper case letter"
@@ -136,10 +140,59 @@ option "title" "Test account names"
   Assets:Test
 
 2018-03-29 * "Mapping creating collision"
-  Assets:Collision                           1 EUR
+  Assets:Collision                       1 EUR
   Equity:Opening-Balance
 
 2018-03-29 * "Mapping creating collision"
-  Assets:Collision                           1 EUR
+  Assets:Collision                       1 EUR
   Equity:Opening-Balance
+
+2018-04-18 * "Preserve whitespace: shorter"
+  Assets:Short                         10.00 EUR
+  Assets:Test                         -10.00 EUR
+
+2018-04-18 * "Preserve whitespace: shorter"
+  Assets:Short    10.00 EUR
+  Assets:Test    -10.00 EUR
+
+2018-04-18 * "Preserve whitespace: shorter"
+  Assets:Short  	10.00 EUR
+  Assets:Test	-10.00 EUR
+
+2018-04-18 * "Preserve whitespace: shorter"
+  Assets:Short
+  Assets:Test                         -10.00 EUR
+
+2018-04-18 * "Preserve whitespace: longer"
+  Assets:MuchLonger                    10.00 EUR
+  Assets:Test                         -10.00 EUR
+
+; Impossible to preserve
+2018-04-18 * "Preserve whitespace: longer"
+  Assets:MuchLonger  10.00 EUR
+  Assets:Test   -10.00 EUR
+
+2018-04-18 * "Preserve whitespace: longer"
+  Assets:MuchLonger	10.00 EUR
+  Assets:Test	-10.00 EUR
+
+2018-04-18 * "Preserve whitespace: longer"
+  Assets:MuchLonger
+  Assets:Test                         -10.00 EUR
+
+2018-04-18 * "Preserve whitespace: same"
+  Assets:Bash                          10.00 EUR
+  Assets:Test                         -10.00 EUR
+
+2018-04-18 * "Preserve whitespace: same"
+  Assets:Bash  10.00 EUR
+  Assets:A    -10.00 EUR
+
+2018-04-18 * "Preserve whitespace: same"
+  Assets:Bash	10.00 EUR
+  Assets:Test	-10.00 EUR
+
+2018-04-18 * "Preserve whitespace: same"
+  Assets:Bash
+  Assets:Test                         -10.00 EUR
 

--- a/tests/accounts.ledger
+++ b/tests/accounts.ledger
@@ -122,3 +122,52 @@ commodity EUR
     Assets:Coll2                           1 EUR
     Equity:Opening-Balance
 
+2018-04-18 * Preserve whitespace: shorter
+  Assets:Shorter                       10.00 EUR
+  Assets:Test                         -10.00 EUR
+
+2018-04-18 * Preserve whitespace: shorter
+  Assets:Shorter  10.00 EUR
+  Assets:Test    -10.00 EUR
+
+2018-04-18 * Preserve whitespace: shorter
+  Assets:Shorter	10.00 EUR
+  Assets:Test	-10.00 EUR
+
+2018-04-18 * Preserve whitespace: shorter
+  Assets:Shorter
+  Assets:Test                         -10.00 EUR
+
+2018-04-18 * Preserve whitespace: longer
+  Assets:Longer                        10.00 EUR
+  Assets:Test                         -10.00 EUR
+
+; Impossible to preserve
+2018-04-18 * Preserve whitespace: longer
+  Assets:Longer  10.00 EUR
+  Assets:Test   -10.00 EUR
+
+2018-04-18 * Preserve whitespace: longer
+  Assets:Longer	10.00 EUR
+  Assets:Test	-10.00 EUR
+
+2018-04-18 * Preserve whitespace: longer
+  Assets:Longer
+  Assets:Test                         -10.00 EUR
+
+2018-04-18 * Preserve whitespace: same
+  Assets:Cash                          10.00 EUR
+  Assets:Test                         -10.00 EUR
+
+2018-04-18 * Preserve whitespace: same
+  Assets:Cash  10.00 EUR
+  Assets:A    -10.00 EUR
+
+2018-04-18 * Preserve whitespace: same
+  Assets:Cash	10.00 EUR
+  Assets:Test	-10.00 EUR
+
+2018-04-18 * Preserve whitespace: same
+  Assets:Cash
+  Assets:Test                         -10.00 EUR
+

--- a/tests/accounts.yml
+++ b/tests/accounts.yml
@@ -7,4 +7,7 @@ account_map:
   Assets:Coll1: Assets:Collision
   Assets:Coll2: Assets:Collision
   Equity:Opening-balance: Equity:Opening-Balance
+  Assets:Shorter: Assets:Short
+  Assets:Longer: Assets:MuchLonger
+  Assets:Cash: Assets:Bash
 

--- a/tests/virtual-postings.beancount
+++ b/tests/virtual-postings.beancount
@@ -15,6 +15,6 @@
 2018-03-17 * "Virtual posting with brackets"
   Assets:Test                        10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
-  Assets:Wallet                     7.00 EUR
-  Equity:Opening-Balance           -7.00 EUR
+  Assets:Wallet                       7.00 EUR
+  Equity:Opening-Balance             -7.00 EUR
 


### PR DESCRIPTION
Since mapped account names may be shorter or longer than the
original account names, try to keep the whitespace intact when
possible by padding the names.