### PR TITLE
ensure payee_match is predictable

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -49,6 +49,7 @@ $config->set_default(account_open_date => "1970-01-01");
 $config->set_default(commodities_date => "1970-01-01");
 $config->set_default(payee_tag => "");
 $config->set_default(payer_tag => "");
+$config->set_default(payee_match => []);
 $config->set_default(ledger_indent => 4);
 $config->set_default(beancount_indent => 2);
 $config->set_default(automatic_declarations => 1);
@@ -58,6 +59,10 @@ $config->set_default(commodity_map => {"\$" => "USD", "£" => "GBP", "€" => "E
 
 # Make config variables easier to access
 $config = $config->get;
+
+if (ref $config->{payee_match} ne ref []) {
+    die "Config variable payee_match has to be a Yaml list";
+}
 
 # regular expression snippets used for ledger parsing
 my $date_RE = qr/\d+[^ =]+/;
@@ -866,10 +871,16 @@ while (@input) {
 		    last;
 		}
 	    }
-	    foreach my $custom_narration_RE (keys %{$config->{payee_match}}) {
-		if ($narration =~ /$custom_narration_RE/) {
-		    push_payee $config->{payee_match}{$custom_narration_RE};
-		    last;
+	    # Config `payee_match` is an array of hashes
+	    my @payee_match = @{$config->{payee_match}};
+	    my $match = 0;
+	    while (!$match && @payee_match) {
+		my $payee_match = shift @payee_match;
+		foreach my $custom_narration_RE (keys %{$payee_match}) {
+		    if ($narration =~ /$custom_narration_RE/) {
+			push_payee ${$payee_match}{$custom_narration_RE};
+			$match = 1;
+		    }
 		}
 	    }
 	    # ledger "apply tag"

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -310,7 +310,7 @@ found.
 
 Furthermore, you can use `payee_match` to match based on the ledger
 payee field and assign payees according to the match.  This variable
-is a hash consisting of regular expressions and the corresponding
+is a list consisting of regular expressions and the corresponding
 payees.  For example, if your ledger contains a transaction like:
 
     2018-03-18 * Oyster card top-up
@@ -318,7 +318,7 @@ payees.  For example, if your ledger contains a transaction like:
 you can use
 
     payee_match:
-      ^Oyster card top-up: Transport for London
+      - ^Oyster card top-up: Transport for London
 
 to match the line and assign the payee `Transport for London`:
 
@@ -344,7 +344,7 @@ in a case sensitive manner by default.  If you want case insensitive
 matches, you can prefix your pattern with `(?i)`, for example:
 
     payee_match:
-      (?i)^Oyster card top-up: Transport for London
+      - (?i)^Oyster card top-up: Transport for London
 
 Finally, metadata describing a payee or payer will be used to set the
 payee.  The tags used for that information can be specified in

--- a/examples/illustrated.ledger
+++ b/examples/illustrated.ledger
@@ -208,7 +208,7 @@ Y 2017
 
 ; `payee_match` will assign a payee based on the match
 ; payee_match:
-;   ^Oyster top-up: TfL
+;   - ^Oyster top-up: TfL
 ; Assign payee "TfL" to everything matching "Oyster top-up".
 
 ; beancount: 2018-03-28 * "TfL" "Oyster top-up"

--- a/examples/illustrated.yml
+++ b/examples/illustrated.yml
@@ -35,12 +35,12 @@ payer_tag: payer
 payee_split:
   - (?<narration>.*?)\s+\((?<payee>.*)\)
 
-# payee_match: a hash of regular expressions and corresponding
+# payee_match: a list of regular expressions and corresponding
 # payees.  The whole ledger payee becomes the narration and
 # the matched payee from the regular expression becomes the
 # payee.
 payee_match:
-  ^Oyster top-up: TfL
+  - ^Oyster top-up: TfL
 
 account_map:
   "Equity:Opening-balance": Equity:Opening-Balance

--- a/ledger2beancount.yml
+++ b/ledger2beancount.yml
@@ -52,12 +52,12 @@ payer_tag: payer
 payee_split:
   - (?<narration>.*?)\s+\((?<payee>Tesco)\)
 
-# payee_match: a hash of regular expressions and corresponding
+# payee_match: a list of regular expressions and corresponding
 # payees.  The whole ledger payee becomes the narration and
 # the matched payee from the regular expression becomes the
 # payee.
 payee_match:
-  (?i)^Oyster card top-up: TfL
+  - (?i)^Oyster card top-up: TfL
 
 # A hash of account names to be mapped to other account
 # names.

--- a/tests/ledger2beancount.yml
+++ b/tests/ledger2beancount.yml
@@ -17,9 +17,10 @@ payee_split:
   - (?<narration>.*?)\s+\((?<payee>Tesco)\)
 
 payee_match:
-  (?i)^Oyster card top-up: TfL
-  ^Marriott reward1.*\(£\d+\.\d+\): Creation
-  ^Marriott reward2.*\(.\d+\.\d+\): Creation
+  - (?i)^Oyster card top-up: TfL
+  - ^Marriott reward1.*\(£\d+\.\d+\): Creation
+  - ^Marriott reward2.*\(.\d+\.\d+\): Creation
+  - test: test
 
 account_map:
   "Equity:Opening-balance": Equity:Opening-Balance


### PR DESCRIPTION
payee_match is a hash of regex matches.  The problem with this is that
the order of the hash is not fixed, so we can get different results if
two regular expressions in the hash match the same line.  Use a Yaml
list instead.

Fixes #114