### PR TITLE
allow UTF-8 letters and digits in account names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ meaningful for accounting reasons but still valuable (e.g., comments,
 formatting, etc.) can be preserved.
 
 The syntax of beancount is expected to become slightly less restrictive
-as some missing features are implemented (such as UTF-8 for account names
-and tags on a posting-level).  ledger2beancount aims to be compatible with
-the latest official release of beancount, but some functionality may
-require an unreleased version of beancount.  Please check the [manual on
-compatibility with beancount](docs/manual.md#beancount-compatibility).
+as some missing features are implemented (such as posting-level tags).
+ledger2beancount aims to be compatible with the latest official release
+of beancount, but some functionality may require an unreleased version
+of beancount.  Please check the [manual on compatibility with
+beancount](docs/manual.md#beancount-compatibility).
 
 Please [read the manual](docs/manual.md) on how to install, configure and
 use ledger2beancount.  The [supported features](docs/manual.md#features)

--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -457,7 +457,7 @@ sub map_account_apply($) {
 # by two spaces, a tab or the end of the line.
 # beancount accounts: "account names begin with a capital letter or a
 # number and are followed letters, numbers or dash (-) characters. All
-# other characters are disallowed."
+# other characters are disallowed." (Letters and numbers may be UTF-8)
 sub map_account($) {
     my ($account) = @_;
 
@@ -472,10 +472,7 @@ sub map_account($) {
     $account = $config->{account_map}{$account} if exists $config->{account_map}{$account};
     $account =~ s/(^|:)(\p{lower})/$1\U$2\E/g; # Make first letter uppercase
     $account =~ s/:[^\p{letter}\p{number}]/:X/g; # Make sure first character is a letter or number
-    # Work around lack of Unicode support (beancount #161)
-    $account = NFKD $account;
-    $account =~ s/\p{NonspacingMark}//g;
-    $account =~ s/[^a-zA-Z0-9:-]/-/g; # Replace disallowed characters
+    $account =~ s/[^\p{letter}\p{number}:-]/-/g; # Replace disallowed characters
     $account = $config->{account_map}{$account} if exists $config->{account_map}{$account};
     $account_declared{$account} = undef if not defined $account_declared{$account};
     return $account;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## 1.2 (unreleased)
 
 * Updates for beancount 2.1.0:
+    * Allow UTF-8 letters and digits in account names
     * Allow full-line comments in transactions
     * Allow transaction tags and links on multiple lines
 * Handle posting tags on multiple lines

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -9,10 +9,8 @@ Conversion is based on (concrete) syntax, so that information that are not
 meaningful for accounting reasons but still valuable (e.g., comments,
 formatting, etc.) can be preserved.
 
-The syntax of beancount is expected to become slightly less restrictive
-as some missing features are implemented (such as UTF-8 for account names
-and tags on a posting-level).  ledger2beancount aims to be compatible with
-the latest official release of beancount.
+ledger2beancount aims to be compatible with the latest official release of
+beancount.
 
 
 Installation
@@ -117,7 +115,7 @@ Beancount compatibility
 
 The syntax of beancount is quite stable but it's expected to become
 slightly less restrictive as some missing features are implemented (such
-as UTF-8 for account names and tags on a posting-level).
+as posting-level tags).
 
 ledger2beancount aims to be compatible with the latest official release
 of beancount, but some functionality may require an unreleased version of
@@ -126,10 +124,13 @@ directly from the beancount repository:
 
     pip3 install hg+https://bitbucket.org/blais/beancount/
 
-Currently, an unreleased version of beancount is required if you use
-full-line comments in transactions and transaction tags on multiple
-lines.  Support for these features was added after beancount 2.0.0 came
-out.
+Currently, an unreleased version of beancount is required if you use:
+
+* UTF-8 letters and digits in account names
+* Full-line comments in transactions
+* Transaction tags on multiple lines
+
+Support for these features was added after beancount 2.0.0 came out.
 
 
 Features
@@ -181,10 +182,7 @@ automatically:
    (`Liabilities:Credit Card` becomes `Liabilities:Credit-Card`)
 2. Replaces account names starting with lower case letters with
    upper case letters (`Assets:test` becomes `Assets:Test`)
-3. Strips accents and umlauts because they are currently not
-   supported in beancount ([issue
-   161](https://bitbucket.org/blais/beancount/issues/161)).
-4. Ensures the first letter is a letter or number by replacing
+3. Ensures the first letter is a letter or number by replacing
    a non-letter first character with an `X`.
 
 While these transformations lead to valid beancount account names,

--- a/examples/illustrated.ledger
+++ b/examples/illustrated.ledger
@@ -45,12 +45,8 @@ account Liabilities:Credit Card_Test
     Assets:MyLedger                     10.00 EUR
     Assets:B
 
-; Beancount currently doesn't support UTF-8 in account names.  Therefore,
-; ledger2beancount strips away accents and umlauts:
-
-; Assets:Föö -> Assets:Foo
-; Assets:École -> Assets:Ecole
-2018-03-28 * No accents or umlauts in account names
+; Account names may contain UTF-8 letters but commodities must not
+2018-03-28 * Account names may contain UTF-8 letters
     Assets:Föö                          10.00 EUR
     Assets:École
 

--- a/tests/accounts.beancount
+++ b/tests/accounts.beancount
@@ -3,8 +3,8 @@
 ;   - Account Assets:test renamed to Assets:Test
 ;   - Account Assets:♚_DASD!;?@#$!%^& *"(*(0-;♚ds renamed to Assets:X-DASD----------------0---ds
 ;   - Account Assets:♚foo:♚bar renamed to Assets:Xfoo:Xbar
-;   - Account Expenses:École républicaine renamed to Expenses:Ecole-republicaine
-;   - Account Expenses:école renamed to Expenses:Ecole
+;   - Account Expenses:École républicaine renamed to Expenses:École-républicaine
+;   - Account Expenses:école renamed to Expenses:École
 ;   - Account Liabilities:Credit Card:Test renamed to Liabilities:Credit-Card:Test
 ;   - Account Liabilities:credit Card:test renamed to Liabilities:Credit-Card:Test
 ;   - Account assets:test renamed to Assets:Test
@@ -23,6 +23,7 @@ option "title" "Test account names"
 1970-01-01 open Assets:Collision
 1970-01-01 open Assets:MuchLonger
 1970-01-01 open Assets:Short
+; Beancount: 2.1.0
 
 1970-01-01 open Assets:Test
   description: "Test account"
@@ -37,8 +38,8 @@ option "title" "Test account names"
 1970-01-01 open Assets:Vouchers:99test
 1970-01-01 open Assets:X-DASD----------------0---ds
 1970-01-01 open Assets:Xfoo:Xbar
-1970-01-01 open Expenses:Ecole-republicaine
-1970-01-01 open Expenses:Ecole
+1970-01-01 open Expenses:École-républicaine
+1970-01-01 open Expenses:École
 1970-01-01 open Assets:Crowns
 1970-01-01 open Assets:Test:I-Love-Crowns
 1970-01-01 open Assets:Commodity-Test123
@@ -124,11 +125,11 @@ option "title" "Test account names"
   Equity:Opening-Balance            -10.00 EUR
 
 2018-03-26 * "Drop accents"
-  Expenses:Ecole-republicaine        10.00 EUR
+  Expenses:École-républicaine        10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
 
 2018-03-26 * "Ensure first letter is upper case letter"
-  Expenses:Ecole                     10.00 EUR
+  Expenses:École                     10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
 
 2018-03-27 * "Account name could be mistaken for commodity"

--- a/tests/accounts.ledger
+++ b/tests/accounts.ledger
@@ -1,3 +1,4 @@
+; Beancount: 2.1.0
 
 account Assets:Test
     note Test account


### PR DESCRIPTION
Beancount allows UTF-8 letters and digits now, so update map_account()
accordingly.