### PR TITLE
improve parsing of the transaction header

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -67,7 +67,7 @@ if (ref $config->{payee_match} ne ref []) {
 # regular expression snippets used for ledger parsing
 my $date_RE = qr/\d+[^ =]+/;
 my $flags_RE = qr/[*!]/;
-my $txn_header_RE = qr/^(?<date>$date_RE)(=(?<auxdate>$date_RE))?\s*(?<flag>$flags_RE)?(\s+\((?<code>.*?)\))?\s+(?<narration>.*)/;
+my $txn_header_RE = qr/^(?<date>$date_RE)(=(?<auxdate>$date_RE))?(\s+|$)(?<flag>$flags_RE)?(\s*\((?<code>[^)]*)\))?\s*(?<narration>.*)/;
 my $tags_RE = qr/(?<tags>[\w:-]+)/;
 # An account can be pretty much anything but it has to be followed by
 # two spaces, a tab or new line (see $posting_RE).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
     * Allow transaction tags and links on multiple lines
 * Handle posting tags on multiple lines
 * Always convert posting-level tags to metadata.
+* Improve parsing of the transaction header
 
 ## 1.1 (2018-05-01)
 

--- a/tests/code.beancount
+++ b/tests/code.beancount
@@ -22,3 +22,23 @@
   Assets:Test                        10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
 
+2018-05-16 * "Code without space"
+  code: "1201"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-05-16 * "Code without space"
+  code: "AT20"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-05-16 txn "Code without space, no flag"
+  code: "1201"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-05-16 txn "Code without space, no flag"
+  code: "AT20"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+

--- a/tests/code.ledger
+++ b/tests/code.ledger
@@ -19,3 +19,19 @@ commodity EUR
     Assets:Test                        10.00 EUR
     Equity:Opening-Balance            -10.00 EUR
 
+2018-05-16 *(1201)Code without space
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-05-16 *(AT20)Code without space
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-05-16 (1201)Code without space, no flag
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-05-16 (AT20)Code without space, no flag
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+

--- a/tests/narration.beancount
+++ b/tests/narration.beancount
@@ -8,3 +8,17 @@
   Assets:Test                        10.00 EUR
   Equity:Opening-Balance            -10.00 EUR
 
+; empty narration
+2018-05-16 txn ""
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+; empty narration with flag
+2018-05-16 * ""
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2018-05-16 * "No space between flag and narration"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+

--- a/tests/narration.ledger
+++ b/tests/narration.ledger
@@ -8,3 +8,17 @@ commodity EUR
     Assets:Test                        10.00 EUR
     Equity:Opening-Balance            -10.00 EUR
 
+; empty narration
+2018-05-16
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+; empty narration with flag
+2018-05-16 *
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2018-05-16 *No space between flag and narration
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+


### PR DESCRIPTION
Jelmer Vernooĳ pointed out that ledger allows a transaction header
which solely consists of a date (i.e. no flag or narration).  As
it turns out, ledger also doesn't require space between flag, code
and narration (but requires a space after the date).

Fixes #123