### PR TITLE
Handle amounts without leading zeroes

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -79,7 +79,7 @@ my $value_exp_RE = qr/$value_RE([\h*\/+-]*$value_RE)?/;
 # between quotes.
 my $commodity_quoted_RE = qr/(["'])(?:(?=(\\?))\g{-1}.)*?\g{-2}/;
 # An unquoted commodity may not contain certain characters
-my $commodity_unquoted_RE = qr/(?!-)[^;\s0-9)("'{}@*\/+-]+/;
+my $commodity_unquoted_RE = qr/(?!-)[^;\s0-9)("'{}@*\/+,.-]+/;
 my $commodity_RE = qr/$commodity_quoted_RE|$commodity_unquoted_RE/;
 # Ledger supports three different amount formats:
 # [minus] amount commodity
@@ -261,6 +261,10 @@ sub pp_amount($$$$) {
 	$value =~ s/\.//g;
 	$value =~ s/,/./; # issue #204
     }
+
+    # ledger allows amounts without a leading zero (e.g. 0.10) but
+    # beancount doesn't.
+    $value = "0$value" if $value =~ /^[\.,]/;
 
     return sprintf "%s%s%s%s %s", $inline_math ? "(" : "",
 	$minus =~ "^-" ? "-" : "", $value,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## 1.3 (unreleased)
 
 * Handle tags on the same line as postings correctly
+* Handle amounts without leading zeroes
 
 ## 1.2 (2018-05-17)
 

--- a/tests/amounts-decimal-comma.beancount
+++ b/tests/amounts-decimal-comma.beancount
@@ -1,3 +1,11 @@
+;----------------------------------------------------------------------
+; ledger2beancount conversion notes:
+;   - Collision for commodity "EUR": EUR, €
+;----------------------------------------------------------------------
+
+1970-01-01 open Assets:Test
+1970-01-01 commodity GBP
+1970-01-01 commodity USD
 
 1970-01-01 open Assets:99Test:Test99
 1970-01-01 open Equity:Opening-Balance
@@ -15,4 +23,12 @@
 2018-03-26 * "Decimal comma, with thousand separator"
   Assets:99Test:Test99            1000.00 EUR
   Equity:Opening-Balance
+
+2018-09-27 * "Test amounts without digits before comma separator"
+  Assets:Test                        0.10 EUR
+  Assets:Test                       -0.10 EUR
+  Assets:Test                        0.10 GBP
+  Assets:Test                       -0.10 GBP
+  Assets:Test                        0.10 USD
+  Assets:Test                      -0.10 USD
 

--- a/tests/amounts-decimal-comma.ledger
+++ b/tests/amounts-decimal-comma.ledger
@@ -17,3 +17,11 @@ commodity EUR
     Assets:99Test:Test99            EUR 1.000,00
     Equity:Opening-Balance
 
+2018-09-27 * Test amounts without digits before comma separator
+    Assets:Test                        €,10
+    Assets:Test                       €-,10
+    Assets:Test                        £,10
+    Assets:Test                       £-,10
+    Assets:Test                        $,10
+    Assets:Test                      $-0,10
+

--- a/tests/amounts.beancount
+++ b/tests/amounts.beancount
@@ -1,16 +1,20 @@
 ;----------------------------------------------------------------------
 ; ledger2beancount conversion notes:
 ;   - Commodity Avios renamed to AVIOS
+;   - Collision for commodity "EUR": EUR, €
+;   - Collision for commodity "GBP": GBP, £
 ;   - Collision for commodity "USD": $, USD
 ;----------------------------------------------------------------------
 
 1970-01-01 open Assets:Current
 1970-01-01 open Assets:Receivable
 1970-01-01 open Assets:Rewards
+1970-01-01 open Assets:Test
 1970-01-01 open Expenses:Housing:Rent
 1970-01-01 open Expenses:Travel:Airfare
 1970-01-01 open Liabilities:BA
 1970-01-01 commodity AVIOS
+1970-01-01 commodity CZK
 
 1970-01-01 open Assets:99Test:Test99
 1970-01-01 open Assets:Test1
@@ -135,4 +139,14 @@
   Expenses:Housing:Rent         (550.00/2) GBP
   Assets:Receivable             (550.00/2) GBP
   Assets:Current                   -550.00 GBP
+
+2018-09-27 * "Test amounts without digits before point separator"
+  Assets:Test                        0.10 EUR
+  Assets:Test                       -0.10 EUR
+  Assets:Test                        0.10 GBP
+  Assets:Test                       -0.10 GBP
+  Assets:Test                        0.10 USD
+  Assets:Test                      -0.10 USD
+  Assets:Test     19,200 CZK @ 0.04585052 USD
+  Assets:Test                    -880.33 USD
 

--- a/tests/amounts.ledger
+++ b/tests/amounts.ledger
@@ -123,3 +123,13 @@ commodity $
     Assets:Receivable             (550.00/2 GBP)
     Assets:Current                   -550.00 GBP
 
+2018-09-27 * Test amounts without digits before point separator
+    Assets:Test                        €.10
+    Assets:Test                       €-.10
+    Assets:Test                        £.10
+    Assets:Test                       -£.10
+    Assets:Test                        $.10
+    Assets:Test                      $-0.10
+    Assets:Test     19,200 CZK @ $.04585052
+    Assets:Test                    -$880.33
+


### PR DESCRIPTION
ledger allows amounts without leading zeroes, e.g. $.10.  Fix the
parsing of such amounts and add the leading zero because beancount
expects it.

Fixes #135