### PR TITLE
avoid parsing whitespace as the account name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,12 @@ indent_style = space
 indent_size = 2
 indent_style = space
 
+[tests/accounts.ledger]
+trim_trailing_whitespace = false
+
+[tests/accounts.beancount]
+trim_trailing_whitespace = false
+
 [tests/metadata.beancount]
 trim_trailing_whitespace = false
 

--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -72,7 +72,7 @@ my $txn_header_RE = qr/^(?<date>$date_RE)(=(?<auxdate>$date_RE))?(\s+|$)(?<flag>
 my $tags_RE = qr/(?<tags>[\w:-]+)/;
 # An account can be pretty much anything but it has to be followed by
 # two spaces, a tab or new line (see $posting_RE).
-my $account_RE = qr/[^\s]([^\t](?!  )(?!\)  )(?!\]  ))*.?/;
+my $account_RE = qr/[^\s]([^\t](?!(\]|\))?(  | \t|\s*$)))*.?/;
 my $value_RE = qr/[\d.,]+/;
 my $value_exp_RE = qr/$value_RE([\h*\/+-]*$value_RE)?/;
 # A quoted commodity ("LU0274208692") can contain anything
@@ -92,7 +92,7 @@ my $amount_RE = qr/(?<inline_math>\(?)($amount_mnc_RE|$amount_cmn_RE|$amount_mcn
 my $comment_top_level_RE = qr/[;#%|*]\s?(?<comment>.*?)/;
 my $comment_RE = qr/;\s*(?<comment>.*)/;
 my $metadata_RE = qr/;\s*(?<key>[^\h:][^\h]*?):(?<typed>:)?\s+(?<value>.*)/;
-my $posting_RE = qr/(?<posting>((?<flag>$flags_RE)\s+)?(?<virtual>[(\[]\s?)?(?<account>$account_RE)(  |\t|$|\)|\])\s*(?<amount>$amount_RE)?(?<auxdatestrip>\s*;\s*\[=(?<auxdate>$date_RE)\])?)/;
+my $posting_RE = qr/(?<posting>((?<flag>$flags_RE)\s+)?(?<virtual>[(\[]\s?)?(?<account>$account_RE)(  | \t|\t|\s*$|\)|\])\s*(?<amount>$amount_RE)?(?<auxdatestrip>\s*;\s*\[=(?<auxdate>$date_RE)\])?)/;
 my $price_RE = qr/^P\s+(?<date>$date_RE)\s+(\d\d:\d\d(:\d\d)?\s+)?(?<commodity1>$commodity_RE)\s+(?<value>$value_RE)\s+(?<commodity2>$commodity_RE)/;
 
 # Maximum limit for beancount commodities

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # ledger2beancount releases
 
+## 1.4 (unreleased)
+
+* Don't parse trailing whitespace as part of the account name
+
 ## 1.3 (2018-09-29)
 
 * Handle tags on the same line as postings correctly

--- a/tests/accounts.beancount
+++ b/tests/accounts.beancount
@@ -19,6 +19,7 @@
 option "title" "Test account names"
 
 1970-01-01 open Assets:A
+1970-01-01 open Assets:Bank
 1970-01-01 open Assets:Bash
 1970-01-01 open Assets:Collision
 1970-01-01 open Assets:MuchLonger
@@ -196,4 +197,36 @@ option "title" "Test account names"
 2018-04-18 * "Preserve whitespace: same"
   Assets:Bash
   Assets:Test                         -10.00 EUR
+
+2018-10-22 txn "Whitespace is not part of account name"
+  Assets:Test                      10.00 EUR
+  Assets:Bank 	            -10.00 EUR
+
+2018-10-22 txn "Whitespace is not part of account name"
+  Assets:Test                      10.00 EUR
+  Assets:Bank   	            -10.00 EUR
+
+2018-10-22 txn "Trailing whitespace is not part of account name"
+  Assets:Test                      10.00 EUR
+  Assets:Bank 
+
+2018-10-22 txn "Trailing whitespace is not part of account name"
+  Assets:Test                      10.00 EUR
+  Assets:Bank	
+
+2018-10-22 txn "Trailing whitespace is not part of account name"
+  Assets:Test                      10.00 EUR
+  Assets:Bank 	
+
+2018-10-22 txn "Trailing whitespace is not part of account name"
+  Assets:Test                      10.00 EUR
+  Assets:Bank   
+
+2018-10-22 txn "Trailing whitespace is not part of account name"
+  Assets:Test                      10.00 EUR
+  Assets:Bank  	
+
+2018-10-22 txn "Trailing whitespace is not part of account name"
+  Assets:Test                      10.00 EUR
+  Assets:Bank   	
 

--- a/tests/accounts.ledger
+++ b/tests/accounts.ledger
@@ -172,3 +172,35 @@ commodity EUR
   Assets:Cash
   Assets:Test                         -10.00 EUR
 
+2018-10-22 Whitespace is not part of account name
+    Assets:Test                      10.00 EUR
+    Assets:Bank 	            -10.00 EUR
+
+2018-10-22 Whitespace is not part of account name
+    Assets:Test                      10.00 EUR
+    [Assets:Bank] 	            -10.00 EUR
+
+2018-10-22 Trailing whitespace is not part of account name
+    Assets:Test                      10.00 EUR
+    Assets:Bank 
+
+2018-10-22 Trailing whitespace is not part of account name
+    Assets:Test                      10.00 EUR
+    Assets:Bank	
+
+2018-10-22 Trailing whitespace is not part of account name
+    Assets:Test                      10.00 EUR
+    Assets:Bank 	
+
+2018-10-22 Trailing whitespace is not part of account name
+    Assets:Test                      10.00 EUR
+    [Assets:Bank] 
+
+2018-10-22 Trailing whitespace is not part of account name
+    Assets:Test                      10.00 EUR
+    [Assets:Bank]	
+
+2018-10-22 Trailing whitespace is not part of account name
+    Assets:Test                      10.00 EUR
+    [Assets:Bank] 	
+

--- a/tests/accounts.yml
+++ b/tests/accounts.yml
@@ -1,6 +1,8 @@
 
 beancount_header: accounts.header
 
+convert_virtual: true
+
 account_map:
   Assets:♚♛♕♔: Assets:Crowns
   Assets:Test:I love ♚♛♕♔: Assets:Test:I-Love-Crowns


### PR DESCRIPTION
There were two cases in which ledger2beancount incorrectly parsed
whitespace as part of the account name:

1) when an account name was followed by a single space, followed by
a tab (#140)

2) trailing whitespace after an account name which is not followed
by an amount (#141).

Fixes #140 and fixes #141