### PR TITLE
Don't require whitespace between {} and @ in lot information

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -680,7 +680,7 @@ sub process_txn(@) {
 		# posting with balance assertion
 		push_line $depth, replace_commodity $+{posting};
 		push_assertion $+{account}, $+{assertion};
-	    } elsif ($has_amount && $l =~ /^$posting_RE(\s+(?<curlyopen>\{\{?)\s*(?<lot_cost>$amount_RE)\s*(?<curlyclose>\}\}?))?\s*(\[(?<date>$date_RE)\])?\s*(\((?<lot_note>[^@].*)\))?\s*(\(?(?<at>@@?)\)?\s+(?<lot_price>$amount_RE))?(\s*$comment_RE)?/) {
+	    } elsif ($has_amount && $l =~ /^$posting_RE(\s*(?<curlyopen>\{\{?)\s*(?<lot_cost>$amount_RE)\s*(?<curlyclose>\}\}?))?\s*(\[(?<date>$date_RE)\])?\s*(\((?<lot_note>[^@].*)\))?\s*(\(?(?<at>@@?)\)?\s*(?<lot_price>$amount_RE))?(\s*$comment_RE)?/) {
 		# posting with unit price and optional lot price
 		# XXX refactor/merge with previous regex case
 		my $lot_info = "";

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 * Don't parse trailing whitespace as part of the account name
 * Replace commodities in lot costs
 * Avoid mangling of lot cost with other lot information
+* Don't require whitespace between {} and @ in lot information
 
 ## 1.3 (2018-09-29)
 

--- a/tests/lots.beancount
+++ b/tests/lots.beancount
@@ -47,7 +47,19 @@
   Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * "Test"
+  Assets:Test               10.00 EUR {0.90 GBP}
+  Equity:Opening-Balance    -9.00 GBP
+
+2018-03-17 * "Test"
+  Assets:Test               10.00 EUR {0.90 GBP}
+  Equity:Opening-Balance    -9.00 GBP
+
+2018-03-17 * "Test"
   Assets:Test               10.00 EUR {{9 GBP}}
+  Equity:Opening-Balance    -9.00 GBP
+
+2018-03-17 * "Test"
+  Assets:Test               10.00 EUR {0.90 GBP}
   Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * "Test"
@@ -216,6 +228,10 @@
   Assets:Test               10.00 EUR {1.23 USD, "this is a note"} ; comment
   Equity:Opening-Balance   -12.30 USD
 
+2018-04-22 * "Lot with comment, no space"
+  Assets:Test               10.00 EUR {1.23 USD, "this is a note"} @ 1.30 USD ; comment
+  Assets:Bank
+
 2018-10-22 * "Commodity conversion of lot cost"
   Expenses:Test              2361.00 EUR {1.3831 USD} @ 1.4056 USD
   Expenses:Currency              53.12 USD
@@ -225,7 +241,15 @@
   Expenses:Test         416.00 EUR {1.2937 USD, 2012-05-12} @ 1.30 USD
   Assets:Bank
 
+2018-10-23 * "Lot information, no space"
+  Expenses:Test         416.00 EUR {1.2937 USD, 2012-05-12} @ 1.30 USD
+  Assets:Bank
+
 2018-10-23 * "Lot information"
+  Expenses:Test         416.00 EUR {1.2937 USD, 2012-05-12} @ 1.30 USD
+  Assets:Bank
+
+2018-10-23 * "Lot information, no space"
   Expenses:Test         416.00 EUR {1.2937 USD, 2012-05-12} @ 1.30 USD
   Assets:Bank
 

--- a/tests/lots.ledger
+++ b/tests/lots.ledger
@@ -37,11 +37,23 @@ commodity XXXx
     Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * Test
+    Assets:Test               10.00 EUR{   0.90 GBP }
+    Equity:Opening-Balance    -9.00 GBP
+
+2018-03-17 * Test
+    Assets:Test               10.00 EUR{0.90 GBP}
+    Equity:Opening-Balance    -9.00 GBP
+
+2018-03-17 * Test
     Assets:Test               10.00 EUR {{ 9 GBP}}
     Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * Test
     Assets:Test               10.00 EUR {0.90 GBP} @ 0.90 GBP
+    Equity:Opening-Balance    -9.00 GBP
+
+2018-03-17 * Test
+    Assets:Test               10.00 EUR{0.90 GBP}@0.90 GBP
     Equity:Opening-Balance    -9.00 GBP
 
 2018-03-17 * Test
@@ -206,6 +218,10 @@ commodity XXXx
     Assets:Test               10.00 EUR {1.23 USD} (this is a note) @ 1.23 USD ; comment
     Equity:Opening-Balance   -12.30 USD
 
+2018-04-22 * Lot with comment, no space
+    Assets:Test               10.00 EUR{1.23 USD}(this is a note)@1.30 USD; comment
+    Assets:Bank
+
 2018-10-22 * Commodity conversion of lot cost
     Expenses:Test              €2361.00 {$1.3831} @ $1.4056
     Expenses:Currency              $53.12
@@ -215,8 +231,16 @@ commodity XXXx
     Expenses:Test         €416.00 {$1.2937} [2012-05-12] @ $1.30
     Assets:Bank
 
+2018-10-23 * Lot information, no space
+    Expenses:Test         €416.00{$1.2937}[2012-05-12]@$1.30
+    Assets:Bank
+
 2018-10-23 * Lot information
     Expenses:Test         416.00 EUR {1.2937 USD} [2012-05-12] @ 1.30 USD
+    Assets:Bank
+
+2018-10-23 * Lot information, no space
+    Expenses:Test         416.00 EUR{1.2937 USD}[2012-05-12]@1.30 USD
     Assets:Bank
 
 2018-10-23 * Lot information


### PR DESCRIPTION
Whitespace is entirely optional for all lot information - don't
require whitespace before {} and @.

Fixes #149