### PR TITLE
Add support for posting-level dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Please refer to [the manual](docs/manual.md#features) for more details.
 * Amounts
   * Decimal comma (not supported in beancount)
 * Dates
+  * Dates on posting-level (no equivalence in beancount)
   * Auxiliary dates (no equivalence in beancount)
   * Effective dates (no equivalence in beancount)
 * Directives

--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -92,7 +92,7 @@ my $amount_RE = qr/(?<inline_math>\(?)($amount_mnc_RE|$amount_cmn_RE|$amount_mcn
 my $comment_top_level_RE = qr/[;#%|*]\s?(?<comment>.*?)/;
 my $comment_RE = qr/;\s*(?<comment>.*)/;
 my $metadata_RE = qr/;\s*(?<key>[^\h:][^\h]*?):(?<typed>:)?\s+(?<value>.*)/;
-my $posting_RE = qr/(?<posting>((?<flag>$flags_RE)\s+)?(?<virtual>[(\[]\s?)?(?<account>$account_RE)(  | \t|\t|\s*$|\)|\])\s*(?<amount>$amount_RE)?(?<auxdatestrip>\s*;\s*\[=(?<auxdate>$date_RE)\])?)/;
+my $posting_RE = qr/(?<posting>((?<flag>$flags_RE)\s+)?(?<virtual>[(\[]\s?)?(?<account>$account_RE)(  | \t|\t|\s*$|\)|\])\s*(?<amount>$amount_RE)?(?<datestrip>\s*;\s*\[(?<postdate>$date_RE)?(=(?<auxdate>$date_RE))?\])?)/;
 my $price_RE = qr/^P\s+(?<date>$date_RE)\s+(\d\d:\d\d(:\d\d)?\s+)?(?<commodity1>$commodity_RE)\s+(?<value>$value_RE)\s+(?<commodity2>$commodity_RE)/;
 
 # Maximum limit for beancount commodities
@@ -660,10 +660,11 @@ sub process_txn(@) {
 		}
 	    }
 	    $in_postings += 1;
+	    my $postdate = $+{postdate};
 	    my $auxdate = $+{auxdate};
 	    my $has_amount = $+{amount} ? 1 : 0;
 	    # Strip the auxdate info
-	    $l =~ s/\s*\Q$+{auxdatestrip}\E// if $+{auxdatestrip};
+	    $l =~ s/\s*\Q$+{datestrip}\E// if $+{datestrip};
 
 	    # Check for posting-level tags and metadata
 	    if ($l =~ s/^($posting_RE)(\s*;\s*:$tags_RE:)/$1/) {
@@ -730,6 +731,7 @@ sub process_txn(@) {
 		push_line $depth, $l;
 	    }
 	    handle_metadata $depth+1, \%metadata_posting if exists $metadata_posting{key};
+	    push_metadata $depth + 1, $config->{postdate_tag}, pp_date $postdate, 0 if defined $postdate && defined $config->{postdate_tag};
 	    push_metadata $depth + 1, $config->{auxdate_tag}, pp_date $auxdate, 0 if defined $auxdate && defined $config->{auxdate_tag};
 	} elsif ($l =~ /^\h*$/) {  # whitespace or blank line
 	    push_line 0, "";

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## 1.5 (unreleased)
 
 * Replace commodities in balance assertions
+* Add support for posting-level dates
 
 ## 1.4 (2018-12-01)
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -278,6 +278,13 @@ Ledger allows dates without a year if the year is declared using the `Y`
 or `year` directive.  If `date_format_no_year` is set, ledger2beancount
 can convert such dates to `YYYY-MM-DD`.
 
+Posting-level dates are recognized by ledger2beancount and stored as
+metadata according to the `postdate_tag` (`date` by default) but this
+has no effect in beancount.  There is
+[a proposal](https://docs.google.com/document/d/1x0qqWGRHi02ef-FtUW172SHkdJ8quOZD-Xli7r4Nl_k/)
+to support this functionality in a different way, but this is not
+implemented in beancount yet.
+
 While ledger2beancount itself doesn't read your ledger config file, the
 script `ledger2beancount-ledger-config` can be used to parse your ledger
 config file (`~/.ledgerrc`) or your ledger file (ledger files may contain

--- a/ledger2beancount.yml
+++ b/ledger2beancount.yml
@@ -73,6 +73,7 @@ commodity_map:
 
 # You can set the following metadata tags to an empty string if you
 # don't want the metadata to be added to beancount.
+postdate_tag: date
 auxdate_tag: aux-date
 code_tag: code
 

--- a/tests/aux-date.beancount
+++ b/tests/aux-date.beancount
@@ -36,3 +36,17 @@
   Assets:Commodity-Test123
     aux-date: 2018-03-13
 
+2019-01-16 * "Posting date using comment"
+  Assets:Test                        10.00 EUR
+    date: 2017-03-04
+  Equity:Opening-Balance            -10.00 EUR
+    date: 2017-07-08
+
+2019-01-16 * "Posting date and aux date using comment"
+  Assets:Test                        10.00 EUR
+    date: 2017-03-04
+    aux-date: 2017-03-05
+  Equity:Opening-Balance            -10.00 EUR
+    date: 2017-07-08
+    aux-date: 2017-07-09
+

--- a/tests/aux-date.ledger
+++ b/tests/aux-date.ledger
@@ -29,3 +29,11 @@ commodity EUR
     Assets:Test                        10.00 EUR
     Assets:Commodity-Test123                     ; [=2018-03-13]
 
+2019-01-16 * Posting date using comment
+    Assets:Test                        10.00 EUR ; [2017-03-04]
+    Equity:Opening-Balance            -10.00 EUR ; [2017-07-08]
+
+2019-01-16 * Posting date and aux date using comment
+    Assets:Test                        10.00 EUR ; [2017-03-04=2017-03-05]
+    Equity:Opening-Balance            -10.00 EUR ; [2017-07-08=2017-07-09]
+

--- a/tests/ledger2beancount.yml
+++ b/tests/ledger2beancount.yml
@@ -40,6 +40,7 @@ commodity_map:
 
 # You can set the following metadata tags to an empty string if you
 # don't want the metadata to be added to beancount.
+postdate_tag: date
 auxdate_tag: aux-date
 code_tag: code
 


### PR DESCRIPTION
In addition to effective dates, ledger has support for dates on the
posting-level.  Store this information as metadata.

The current beancount proposal allows for such posting-level dates.
It will be interesting though what to do if a posting has both a
primary and aux date since that can't be expressed with the beancount
proposal as far as I can tell.

Fixes #125