### PR TITLE
Add support for hledger features

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -67,8 +67,10 @@ if (ref $config->{payee_match} ne ref []) {
 
 # regular expression snippets used for ledger parsing
 my $date_RE = qr/\d+[^ =]+/;
+my $hledger_date_RE = qr#(\d{4}[./-])?\d{1,2}[./-]\d{1,2}#;
 my $flags_RE = qr/[*!]/;
 my $txn_header_RE = qr/^(?<date>$date_RE)(=(?<auxdate>$date_RE))?(\s+|$)(?<flag>$flags_RE)?(\s*\((?<code>[^)]*)\))?\s*(?<narration>.*)/;
+my $hledger_payee_narration_RE = qr/(?<payee>[^|]+?)\s*\|\s*(?<narration>.*)/;
 my $tags_RE = qr/(?<tags>[\w:-]+)/;
 # An account can be pretty much anything but it has to be followed by
 # two spaces, a tab or new line (see $posting_RE).
@@ -733,6 +735,16 @@ sub process_txn(@) {
 	    handle_metadata $depth+1, \%metadata_posting if exists $metadata_posting{key};
 	    push_metadata $depth + 1, $config->{postdate_tag}, pp_date $postdate, 0 if defined $postdate && defined $config->{postdate_tag};
 	    push_metadata $depth + 1, $config->{auxdate_tag}, pp_date $auxdate, 0 if defined $auxdate && defined $config->{auxdate_tag};
+	    if ($config->{hledger} && $l =~ /$comment_RE/) {
+		my $comment = $+{comment};
+		my $year = $1 if $cur_txn_header{date} =~ /^(\d{4})-/;
+		if (defined $config->{postdate_tag} && $comment =~ /date:($hledger_date_RE)/) {
+		    push_metadata $depth + 1, $config->{postdate_tag}, pp_date $1, $year;
+		}
+		if (defined $config->{auxdate_tag} && $comment =~ /date2:($hledger_date_RE)/) {
+		    push_metadata $depth + 1, $config->{auxdate_tag}, pp_date $1, $year;
+		}
+	    }
 	} elsif ($l =~ /^\h*$/) {  # whitespace or blank line
 	    push_line 0, "";
 	} else {  # there shouldn't be anything
@@ -911,6 +923,10 @@ while (@input) {
 	    push_metadata $depth + 1, $config->{code_tag}, mk_beancount_string $+{code} if defined $+{code} && defined $config->{code_tag};
 	    # Determine payee based on the narration field
 	    my $narration = $+{narration};
+	    if ($config->{hledger} && $narration =~ /$hledger_payee_narration_RE/) {
+		push_payee $+{payee};
+		$cur_txn_header{narration} = $+{narration};
+	    }
 	    foreach my $custom_narration_RE (@{$config->{payee_split}}) {
 		if ($narration =~ /$custom_narration_RE/) {
 		    push_payee $+{payee};

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 * Replace commodities in balance assertions
 * Add support for posting-level dates
+* Add support for hledger features
 
 ## 1.4 (2018-12-01)
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -293,9 +293,9 @@ ledger options) to output the correct config option for ledger2beancount.
 
 ### Auxiliary dates
 
-Beancount currently doesn't support ledger's [auxiliary dates (or effective
-dates)](https://www.ledger-cli.org/3.0/doc/ledger3.html#Auxiliary-dates)
-(but there is [a proposal](https://docs.google.com/document/d/1x0qqWGRHi02ef-FtUW172SHkdJ8quOZD-Xli7r4Nl_k/)
+Beancount currently doesn't support ledger's [auxiliary dates](https://www.ledger-cli.org/3.0/doc/ledger3.html#Auxiliary-dates)
+(or effective dates; also known as date2 in hledger) (but there is
+[a proposal](https://docs.google.com/document/d/1x0qqWGRHi02ef-FtUW172SHkdJ8quOZD-Xli7r4Nl_k/)
 to support this functionality in a different way),
 so these are stored as metadata according to the `auxdate_tag` variable.
 Unset the variable if you don't want auxiliary dates to be stored as
@@ -323,6 +323,10 @@ but this also overrides the free-form text to describe the transaction.
 Payees can also be declared explicitly in ledger but this is not required
 by beancount, so such declarations are ignored (they are preserved as
 comments).
+
+hledger allows the separation of payee and narration using the pipe
+character (`payee | narration`).  This is supported by ledger2beancount
+if the `hledger` option is enabled.
 
 Since ledger has limited support for payees, ledger2beancount offers
 several features to determine the payee from the transaction itself.
@@ -600,6 +604,20 @@ following transactions:
 
 Support for more complex inline math would require substantial changes
 to the parser.
+
+
+### hledger syntax
+
+The syntax of [hledger](http://hledger.org/) is largely compatible with
+that of ledger.  If the `hledger` config option is set to `true`,
+ledger2beancount will look for some hledger specific features:
+
+1) hledger allows the [separation of a transaction's description into
+   payee and note](http://hledger.org/journal.html#payee-and-note)
+   (narration) using the pipe character (`payee | narration`).
+
+2) hledger allows `date:` and `date2:` to specify [posting dates](http://hledger.org/journal.html#posting-dates)
+   in posting comments in addition to ledger's `[date=date2]` syntax.
 
 
 ### Ignoring certain lines

--- a/ledger2beancount.yml
+++ b/ledger2beancount.yml
@@ -16,6 +16,9 @@ ledger_indent: 4
 operating_currencies:
   - EUR
 
+# Attempt to parse hledger specific features
+hledger: true
+
 # You can specify a file which serves as a beancount "header", i.e.
 # it's put at the beginning of the converted beancount file.  You can
 # specify options for beancount, such as `option "title"`, define

--- a/tests/hledger.beancount
+++ b/tests/hledger.beancount
@@ -1,0 +1,60 @@
+;----------------------------------------------------------------------
+; ledger2beancount conversion notes:
+;   - Account assets:checking renamed to Assets:Checking
+;   - Account expenses:food renamed to Expenses:Food
+;----------------------------------------------------------------------
+
+1970-01-01 open Assets:A
+1970-01-01 open Assets:B
+1970-01-01 open Assets:Checking
+1970-01-01 open Expenses:Food
+1970-01-01 commodity EUR
+1970-01-01 commodity USD
+
+; Payee and narration
+
+2015-05-30 txn "foo" "bar"
+  Assets:A        10.00 EUR
+  Assets:B       -10.00 EUR
+
+2015-05-30 txn "foo" "bar"
+  Assets:A        10.00 EUR
+  Assets:B       -10.00 EUR
+
+2015-05-30 txn "foo" "bar"
+  Assets:A        10.00 EUR
+  Assets:B       -10.00 EUR
+
+2015-05-30 txn "foo" "bar | baz"
+  Assets:A        10.00 EUR
+  Assets:B       -10.00 EUR
+
+; Posting level dates as comments
+
+2015-05-30 txn "date as comment"
+  Expenses:Food     10 USD   ; food purchased on saturday 05/30
+  Assets:Checking         ; bank cleared it on monday, date:2005/6/01
+    date: 2005-06-01
+
+2015-05-30 txn "date as comment without year"
+  Expenses:Food     10 USD   ; food purchased on saturday 05/30
+  Assets:Checking         ; bank cleared it on monday, date:6/1
+    date: 2015-06-01
+
+2015-05-30 txn "date2 as comment"
+  Expenses:Food     10 USD   ; food purchased on saturday 05/30
+  Assets:Checking         ; bank cleared it on monday, date2:2005/6/2
+    aux-date: 2005-06-02
+
+2015-05-30 txn "date and date2 as comment"
+  Expenses:Food     10 USD   ; food purchased on saturday 05/30
+  Assets:Checking         ; bank cleared it on monday, date:2005/6/01 date2:2005/6/2
+    date: 2005-06-01
+    aux-date: 2005-06-02
+
+2015-05-30 txn "date and date2 as comment, in reverse order"
+  Expenses:Food     10 USD   ; food purchased on saturday 05/30
+  Assets:Checking         ; bank cleared it on monday, date2:2005/6/02, date:2005/6/1
+    date: 2005-06-01
+    aux-date: 2005-06-02
+

--- a/tests/hledger.ledger
+++ b/tests/hledger.ledger
@@ -1,0 +1,41 @@
+
+; Payee and narration
+
+2015/5/30 foo | bar
+    Assets:A        10.00 EUR
+    Assets:B       -10.00 EUR
+
+2015/5/30 foo|bar
+    Assets:A        10.00 EUR
+    Assets:B       -10.00 EUR
+
+2015/5/30 foo| bar
+    Assets:A        10.00 EUR
+    Assets:B       -10.00 EUR
+
+2015/5/30 foo | bar | baz
+    Assets:A        10.00 EUR
+    Assets:B       -10.00 EUR
+
+; Posting level dates as comments
+
+2015/5/30 date as comment
+    expenses:food     $10   ; food purchased on saturday 05/30
+    assets:checking         ; bank cleared it on monday, date:2005/6/01
+
+2015/5/30 date as comment without year
+    expenses:food     $10   ; food purchased on saturday 05/30
+    assets:checking         ; bank cleared it on monday, date:6/1
+
+2015/5/30 date2 as comment
+    expenses:food     $10   ; food purchased on saturday 05/30
+    assets:checking         ; bank cleared it on monday, date2:2005/6/2
+
+2015/5/30 date and date2 as comment
+    expenses:food     $10   ; food purchased on saturday 05/30
+    assets:checking         ; bank cleared it on monday, date:2005/6/01 date2:2005/6/2
+
+2015/5/30 date and date2 as comment, in reverse order
+    expenses:food     $10   ; food purchased on saturday 05/30
+    assets:checking         ; bank cleared it on monday, date2:2005/6/02, date:2005/6/1
+

--- a/tests/hledger.yml
+++ b/tests/hledger.yml
@@ -1,0 +1,9 @@
+
+date_format: "%Y/%m/%d"
+date_format_no_year: "%m/%d"
+
+hledger: true
+
+postdate_tag: date
+auxdate_tag: aux-date
+


### PR DESCRIPTION
The syntax of hledger is largely compatible with that of ledger but
there are some hledger specific features we can support:

1) hledger allows the separation of a transaction's description into
payee and note (narration) using the pipe character.

2) hledger allows date: and date2: to specify posting dates in
posting comments in addition to ledger's [date=date2] syntax.