### PR TITLE
Handle comments on the same line as the payee

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -230,6 +230,9 @@ sub pp_cur_header() {
 	$buf .= (mk_beancount_string $cur_txn_header{payee}) . " ";
     }
     $buf .= mk_beancount_string $cur_txn_header{narration};
+    if (exists $cur_txn_header{comment}) {
+	$buf .= " ; " . $cur_txn_header{comment};
+    }
     if (exists $cur_txn_header{tags}) {
 	$buf .= $cur_txn_header{tags};
     }
@@ -372,6 +375,26 @@ sub push_comment($$) {
     my ($depth, $comment) = @_;
 
     push_line $depth, "; $comment";
+}
+
+
+# Process comments; in particular, look for tags
+sub handle_comment($$) {
+    my ($depth, $l) = @_;
+
+    if ($l =~ /^$comment_RE\s+:$tags_RE:\s*$/
+	or $l =~ /^;\s+:$tags_RE:\s+(?<comment>.*)$/) {  # tags comment
+	if ($in_postings) {
+	    push @cur_txn_tags, split /:/, $+{tags};
+	} else {
+	    print_tags $depth, split /:/, $+{tags};
+	}
+	return $+{comment};
+    } elsif ($l =~ /^$comment_RE/) {  # (every other) comment
+	return $+{comment};
+    } else {
+	die "Can't process comment: $l";
+    }
 }
 
 
@@ -648,16 +671,9 @@ sub process_txn(@) {
 
 	if ($l =~ /^$metadata_RE/) {  # metadata comment
 	    handle_metadata $depth, \%+;
-	} elsif ($l =~ /^$comment_RE\s+:$tags_RE:\s*$/
-	    or $l =~ /^;\s+:$tags_RE:\s+(?<comment>.*)$/) {  # tags comment
-	    if ($in_postings) {
-		push @cur_txn_tags, split /:/, $+{tags};
-	    } else {
-		print_tags $depth, split /:/, $+{tags};
-	    }
-	    push_comment $depth, $+{comment} if $+{comment} ne "";
-	} elsif ($l =~ /^$comment_RE/) {  # (every other) comment
-	    push_comment $depth, $+{comment};
+	} elsif ($l =~ /^$comment_RE/) {
+	    my $comment = handle_comment $depth, $l;
+	    push_comment $depth, $comment if $comment;
 	} elsif ($l =~ /^$posting_RE/) {
 	    print_tags $depth+1, @cur_txn_tags;
 	    @cur_txn_tags = ();
@@ -944,11 +960,15 @@ while (@input) {
     } elsif ($l =~ /^[0-9]/) {
 	if ($l =~ /$txn_header_RE/) {  # txn header
 	    $in_postings = 0;
-	    push_header pp_date($+{date}, $year), $+{flag} ? $+{flag} : "txn", $+{narration};
+	    # You can have a comment on the same line as the payee
+	    my ($narration, $comment) = split /  +;\s*|\t+;\s*/, $+{narration}, 2;
+	    $narration = "" if not $narration;
+	    push_header pp_date($+{date}, $year), $+{flag} ? $+{flag} : "txn", $narration;
+	    $comment = handle_comment $depth + 1, "; $comment" if $comment;
+	    $cur_txn_header{comment} = $comment if $comment;
 	    push_metadata $depth + 1, $config->{auxdate_tag}, pp_date($+{auxdate}, $year) if defined $+{auxdate} && defined $config->{auxdate_tag};
 	    push_metadata $depth + 1, $config->{code_tag}, mk_beancount_string $+{code} if defined $+{code} && defined $config->{code_tag};
 	    # Determine payee based on the narration field
-	    my $narration = $+{narration};
 	    if ($config->{hledger} && $narration =~ /$hledger_payee_narration_RE/) {
 		push_payee $+{payee};
 		$cur_txn_header{narration} = $+{narration};

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 * Add support for posting-level dates
 * Add support for hledger features
 * Add support for balance assignments
+* Handle comments on the same line as the payee
 
 ## 1.4 (2018-12-01)
 

--- a/tests/comments.beancount
+++ b/tests/comments.beancount
@@ -64,3 +64,15 @@
   Assets:Test                        10.00 EUR
   Assets:Commodity-Test123  ; comment
 
+2019-01-25 * "A payee can contain ; without problems"
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2019-01-25 * "You can put a comment on the same line as the payee" ; comment
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2019-01-25 * "You can put a comment on the same line as the payee" ; this is a comment
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+

--- a/tests/comments.ledger
+++ b/tests/comments.ledger
@@ -79,3 +79,15 @@ end comment
     Assets:Test                        10.00 EUR
     Assets:Commodity-Test123  ; comment
 
+2019-01-25 * A payee can contain ; without problems
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2019-01-25 * You can put a comment on the same line as the payee  ; comment
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2019-01-25 * You can put a comment on the same line as the payee  ; this is a comment
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+

--- a/tests/tags.beancount
+++ b/tests/tags.beancount
@@ -59,3 +59,27 @@
   Equity:Opening-Balance            -10.00 EUR
     tags: "quux, quuz"
 
+; This is not a tag; you need two spaces before the comment
+2019-01-25 * "Just a payee description ; :foo:"
+  #bar #baz
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2019-01-25 * "Tag on same line as payee"
+  #foo
+  #bar #baz
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2019-01-25 * "Tag on same line as payee"
+  #foo
+  #bar #baz
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+
+2019-01-25 * "Comment and tag on same line as payee" ; comment
+  #foo
+  #bar #baz
+  Assets:Test                        10.00 EUR
+  Equity:Opening-Balance            -10.00 EUR
+

--- a/tests/tags.ledger
+++ b/tests/tags.ledger
@@ -52,3 +52,24 @@ commodity EUR
         ; :foo:
     Equity:Opening-Balance            -10.00 EUR ; :quux:quuz:
 
+; This is not a tag; you need two spaces before the comment
+2019-01-25 * Just a payee description ; :foo:
+    ; :bar:baz:
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2019-01-25 * Tag on same line as payee  ; :foo:
+    ; :bar:baz:
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2019-01-25 * Tag on same line as payee	; :foo:
+    ; :bar:baz:
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+
+2019-01-25 * Comment and tag on same line as payee  ; comment :foo:
+    ; :bar:baz:
+    Assets:Test                        10.00 EUR
+    Equity:Opening-Balance            -10.00 EUR
+


### PR DESCRIPTION
ledger allows you to have a comment on the same line as the
payee -- they have to be separated by two spaces or a tab.

Fixes #157