### PR TITLE
Use /usr/bin/env to execute perl

### DIFF
--- a/bin/ledger2beancount
+++ b/bin/ledger2beancount
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2016-2018 Stefano Zacchiroli <zack@upsilon.cc>
 #           (C) 2018-2019 Martin Michlmayr <tbm@cyrius.com>


### PR DESCRIPTION
For macs using homebrew perl, hardcoding to `/usr/bin/perl` causes the issue identified over at https://github.com/zacchiro/ledger2beancount/issues/155#issuecomment-478415800